### PR TITLE
feature: erigon snapshot support

### DIFF
--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -32,7 +32,7 @@ For the latest snapshot, please visit [<ins>Polygon Chains Snapshots</ins>](http
 To begin, ensure that your node environment meets the **prerequisites** outlined [here](https://wiki.polygon.technology/docs/operate/full-node-binaries/). Before starting any services, execute the shell script provided below. This script will download and extract the snapshot data, which allows for faster bootstrapping. In our example, we will be using an Ubuntu Linux m5d.4xlarge machine with an 8TB block device attached.
 To transfer the correct chaindata to your disk, follow these steps:
 
-- When prompted, specify the network (mainnet or mumbai) and the client type (heimdall or bor or erigon).
+- When prompted, specify the network ("mainnet" or "mumbai") and the client type ("heimdall" or "bor" or "erigon").
 > The script will automatically handle the download and extraction phases, optimizing disk space by deleting already extracted files.
 - Consider using a Screen session to prevent accidental interruptions during the chaindata download and extraction process.
 

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -27,7 +27,7 @@ For the latest snapshot, please visit [<ins>Polygon Chains Snapshots</ins>](http
 
 :::
 
-## Heimdall/Bor/Erigon Snapshots
+## Client Snapshots
 
 To begin, ensure that your node environment meets the **prerequisites** outlined [here](https://wiki.polygon.technology/docs/operate/full-node-binaries/). Before starting any services, execute the shell script provided below. This script will download and extract the snapshot data, which allows for faster bootstrapping. In our example, we will be using an Ubuntu Linux m5d.4xlarge machine with an 8TB block device attached.
 To transfer the correct chaindata to your disk, follow these steps:

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -19,7 +19,7 @@ image: https://wiki.polygon.technology/img/polygon-wiki.png
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-When setting up a new sentry, validator, or full node server, it is recommended that you use snapshots for faster syncing without having to sync over the network. Using snapshots will save you several days for both Heimdall and Bor.
+When setting up a new sentry, validator, or full node server, it is recommended that you use snapshots for faster syncing without having to sync over the network. Using snapshots will save you several days for both Heimdall and Bor. Note: We no longer support bor archive snapshots due to unsustainable data growth. 
 
 :::tip
 
@@ -27,12 +27,12 @@ For the latest snapshot, please visit [<ins>Polygon Chains Snapshots</ins>](http
 
 :::
 
-## Heimdall/Bor Snapshots
+## Heimdall/Bor/Erigon Snapshots
 
 To begin, ensure that your node environment meets the **prerequisites** outlined [here](https://wiki.polygon.technology/docs/operate/full-node-binaries/). Before starting any services, execute the shell script provided below. This script will download and extract the snapshot data, which allows for faster bootstrapping. In our example, we will be using an Ubuntu Linux m5d.4xlarge machine with an 8TB block device attached.
 To transfer the correct chaindata to your disk, follow these steps:
 
-- When prompted, specify the network (mainnet or mumbai) and the client type (heimdall or bor).
+- When prompted, specify the network (mainnet or mumbai) and the client type (heimdall or bor or erigon).
 > The script will automatically handle the download and extraction phases, optimizing disk space by deleting already extracted files.
 - Consider using a Screen session to prevent accidental interruptions during the chaindata download and extraction process.
 
@@ -47,8 +47,15 @@ function validate_network() {
 }
 
 function validate_client() {
-  if [[ "$1" != "heimdall" && "$1" != "bor" ]]; then
-    echo "Invalid client input. Please enter 'heimdall' or 'bor'."
+  if [[ "$1" != "heimdall" && "$1" != "bor" && "$1" != "erigon" ]]; then
+    echo "Invalid client input. Please enter 'heimdall' or 'bor' or 'erigon'."
+    exit 1
+  fi
+}
+
+function validate_checksum() {
+  if [[ "$1" != "true" && "$1" != "false" ]]; then
+    echo "Invalid checksum input. Please enter 'true' or 'false'."
     exit 1
   fi
 }
@@ -56,14 +63,23 @@ function validate_client() {
 # ask user for network and client type
 read -p "PoSV1 Network (mainnet/mumbai): " network_input
 validate_network "$network_input"
-read -p "Client Type (heimdall/bor): " client_input
+read -p "Client Type (heimdall/bor/erigon): " client_input
 validate_client "$client_input"
 read -p "Directory to Download/Extract: " extract_dir_input
+read -p "Perform checksum verification (true/false): " checksum_input
+validate_checksum "$checksum_input"
 
 # set default values if user input is blank
 network=${network_input:-mumbai}
 client=${client_input:-heimdall}
 extract_dir=${extract_dir_input:-"${client}_extract"}
+checksum=${checksum_input:-false}
+
+# temporary as we transition erigon mainnet snapshots to new incremental model, ETA Aug 2023
+if [[ "$client" == "erigon" && "$network" == "mainnet" ]]; then
+  echo "Erigon bor-mainnet archive snapshots currently unavailable as we transition to incremental snapshot model. ETA Aug 2023."
+  exit 1
+fi
 
 # install dependencies and cursor to extract directory
 sudo apt-get update -y
@@ -73,6 +89,11 @@ cd "$extract_dir"
 
 # download compiled incremental snapshot files list
 aria2c -x6 -s6 "https://snapshot-download.polygon.technology/$client-$network-incremental-compiled-files.txt"
+
+# remove hash lines if user declines checksum verification
+if [ "$checksum" == "false" ]; then
+    sed -i '/checksum/d' $client-$network-incremental-compiled-files.txt
+fi
 
 # download all incremental files, includes automatic checksum verification per increment
 aria2c -x6 -s6 -c --auto-file-renaming=false --max-tries=100 -i $client-$network-incremental-compiled-files.txt
@@ -108,7 +129,7 @@ extract_files $client-$network-incremental-compiled-files.txt
 aria2c -c -m 0 -x6 -s6 -i heimdall-$network-incremental-compiled-files.txt --max-concurrent-downloads=1
 ```
 
-Once the extraction is complete, ensure that you update the datadir configuration of your Heimdall or Bor client to point to the path where the extracted data is located.
+Once the extraction is complete, ensure that you update the datadir configuration of your Heimdall/Bor/Erigon client to point to the path where the extracted data is located.
 This ensures that the systemd services can correctly register the snapshot data when the client starts. 
 If you wish to preserve the default client configuration settings, you can use symbolic links (symlinks).
 
@@ -151,3 +172,17 @@ sudo service bor start
 | approx. data growth daily | 100 GB (bor) + 5 GB (heimdall) | 105 GB |
 | approx. total extracted size | 2.1 TB (bor) + 300 GB (heimdall) | 2.4 TB |
 | suggested disk size (2.5x buffer) | 2.4 TB * 2.5 (natural chain growth) | 6 TB |
+
+**Polygon Mumbai Erigon Archive**
+
+| Metric | Calculation Breakdown | Value |
+| ------ | --------------------- | ----------- |
+| approx. compressed total | 210 GB (erigon) + 35 GB (heimdall) | 245 GB |
+| approx. data growth daily | 4.5 GB (erigon) + .5 GB (heimdall) | 5 GB |
+| approx. total extracted size | 875 GB (erigon) + 50 GB (heimdall) | 925 GB |
+| suggested disk size (2.5x buffer) | 925 GB * 2.5 (natural chain growth) | 2.5 TB | 
+
+**Polygon Mainnet Erigon Archive**
+
+Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental snapshots.
+

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -19,7 +19,7 @@ image: https://wiki.polygon.technology/img/polygon-wiki.png
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-When setting up a new sentry, validator, or full node server, it is recommended that you use snapshots for faster syncing without having to sync over the network. Using snapshots will save you several days for both Heimdall and Bor. Note: We no longer support bor archive snapshots due to unsustainable data growth. 
+When setting up a new sentry, validator, or full node server, it is recommended that you use snapshots for faster syncing without having to sync over the network. Using snapshots will save you several days for both Heimdall and Bor. **Note: We no longer support bor archive snapshots due to unsustainable data growth.** 
 
 :::tip
 

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -129,7 +129,7 @@ extract_files $client-$network-incremental-compiled-files.txt
 aria2c -c -m 0 -x6 -s6 -i heimdall-$network-incremental-compiled-files.txt --max-concurrent-downloads=1
 ```
 
-Once the extraction is complete, ensure that you update the datadir configuration of your Heimdall/Bor/Erigon client to point to the path where the extracted data is located.
+Once the extraction is complete, ensure that you update the datadir configuration of your client to point to the path where the extracted data is located.
 This ensures that the systemd services can correctly register the snapshot data when the client starts. 
 If you wish to preserve the default client configuration settings, you can use symbolic links (symlinks).
 


### PR DESCRIPTION
**purpose:**
- add erigon mumbai archive incremental snapshot support to download/extract script
- make checksum verification optional for users to speed up downloads
- add erigon mumbai archive recommend disk size guidance
- clarify erigon mainnet archive temporarily under maintenance per Polygon eng team

**tests:**
- e2e download/extract/erigon client start fully tested successfully on prod nodes, and snapshot download page also updated accordingly:
<img width="1480" alt="image" src="https://github.com/0xPolygon/wiki/assets/100106211/36e56afd-e67e-40d1-91be-ce11e7425a31">
