### PR TITLE
feature: 1-liner snapshot download/extract cmd

### DIFF
--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -248,5 +248,5 @@ Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental sna
   getting in sync, and performing LevelDB compaction
 - To minimize disk latency, direct attached storage is ideal.
 - In AWS, when using gp3 disk types, we recommend provisioning IOPS of 16000 and
-  throughput of 1000 - this minimizes cost and adds a lot of performance. io2 EBS volumes with matching IOPS and throughput values are similarly performant
+  throughput of 1000 - this minimizes cost and adds a lot of performance. io2 EBS volumes with matching IOPS and throughput values are similarly performant.
 - For GCP, we recommend using performance (SSD) persistent disks (`pd-ssd`) or extreme persistent disks (`pd-extreme`) with similar IOPS and throughput values as seen above

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -244,6 +244,7 @@ Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental sna
 
 
 ## Recommended disk type and IOPS guidance
+
 - Disk IOPS will impact speed of downloading/extracting snapshots,
   getting in sync, and performing LevelDB compaction
 - To minimize disk latency, direct attached storage is ideal.

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -34,7 +34,11 @@ To transfer the correct chaindata to your disk, follow these steps:
 
 - All one has to do is specify the network ("mainnet" or "mumbai") and client type ("heimdall" or "bor" or "erigon") of your desired snapshot and run the following command:
 ```
-curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --network {{ network }} --client {{ client }} --extract-dir chaindata --validate-checksum true
+curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --network {{ network }} --client {{ client }} --extract-dir {{ extract_dir }} --validate-checksum {{ true / false }}
+```
+For example:
+```
+curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --network mainnet --client heimdall --extract-dir data --validate-checksum true
 ```
 > This bash script automatically handles all download and extraction phases, as well as optimizing disk space by deleting already extracted files along the way.
 - --extract-dir and --validate-checksum flags are optional.

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -32,97 +32,146 @@ For the latest snapshot, please visit [<ins>Polygon Chains Snapshots</ins>](http
 To begin, ensure that your node environment meets the **prerequisites** outlined [here](https://wiki.polygon.technology/docs/operate/full-node-binaries/). Before starting any services, execute the shell script provided below. This script will download and extract the snapshot data, which allows for faster bootstrapping. In our example, we will be using an Ubuntu Linux m5d.4xlarge machine with an 8TB block device attached.
 To transfer the correct chaindata to your disk, follow these steps:
 
-- When prompted, specify the network ("mainnet" or "mumbai") and the client type ("heimdall" or "bor" or "erigon").
-> The script will automatically handle the download and extraction phases, optimizing disk space by deleting already extracted files.
+- Specify the network ("mainnet" or "mumbai") and client type ("heimdall" or "bor" or "erigon") of your desired snapshot and run the following command:
+```
+curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --network {{ network }} --client {{ client }} --extract-dir chaindata --validate-checksum true
+```
+> This bash script automatically handles all download and extraction phases, as well as optimizing disk space by deleting already extracted files along the way.
+- --extract-dir and --validate-checksum flags are optional.
 - Consider using a Screen session to prevent accidental interruptions during the chaindata download and extraction process.
+- The raw bash script code is collapsed below for transparency:
 
-```
-#!/bin/bash
-
-function validate_network() {
-  if [[ "$1" != "mainnet" && "$1" != "mumbai" ]]; then
-    echo "Invalid network input. Please enter 'mainnet' or 'mumbai'."
-    exit 1
-  fi
-}
-
-function validate_client() {
-  if [[ "$1" != "heimdall" && "$1" != "bor" && "$1" != "erigon" ]]; then
-    echo "Invalid client input. Please enter 'heimdall' or 'bor' or 'erigon'."
-    exit 1
-  fi
-}
-
-function validate_checksum() {
-  if [[ "$1" != "true" && "$1" != "false" ]]; then
-    echo "Invalid checksum input. Please enter 'true' or 'false'."
-    exit 1
-  fi
-}
-
-# ask user for network and client type
-read -p "PoSV1 Network (mainnet/mumbai): " network_input
-validate_network "$network_input"
-read -p "Client Type (heimdall/bor/erigon): " client_input
-validate_client "$client_input"
-read -p "Directory to Download/Extract: " extract_dir_input
-read -p "Perform checksum verification (true/false): " checksum_input
-validate_checksum "$checksum_input"
-
-# set default values if user input is blank
-network=${network_input:-mumbai}
-client=${client_input:-heimdall}
-extract_dir=${extract_dir_input:-"${client}_extract"}
-checksum=${checksum_input:-false}
-
-# temporary as we transition erigon mainnet snapshots to new incremental model, ETA Aug 2023
-if [[ "$client" == "erigon" && "$network" == "mainnet" ]]; then
-  echo "Erigon bor-mainnet archive snapshots currently unavailable as we transition to incremental snapshot model. ETA Aug 2023."
-  exit 1
-fi
-
-# install dependencies and cursor to extract directory
-sudo apt-get update -y
-sudo apt-get install -y zstd pv aria2
-mkdir -p "$extract_dir"
-cd "$extract_dir"
-
-# download compiled incremental snapshot files list
-aria2c -x6 -s6 "https://snapshot-download.polygon.technology/$client-$network-incremental-compiled-files.txt"
-
-# remove hash lines if user declines checksum verification
-if [ "$checksum" == "false" ]; then
-    sed -i '/checksum/d' $client-$network-incremental-compiled-files.txt
-fi
-
-# download all incremental files, includes automatic checksum verification per increment
-aria2c -x6 -s6 -c --auto-file-renaming=false --max-tries=100 -i $client-$network-incremental-compiled-files.txt
-
-# Don't extract if download failed
-if [ $? -ne 0 ]; then
-    echo "Download failed. Restart the script to resume downloading."
-    exit 1
-fi
-
-# helper method to extract all files and delete already-extracted download data to minimize disk use
-function extract_files() {
-    compiled_files=$1
-    while read -r line; do
-        if [[ "$line" == checksum* ]]; then
-            continue
+<details> 
+  <summary>See code</summary>
+  
+      ```
+      #!/bin/bash
+    
+      function validate_network() {
+        if [[ "$1" != "mainnet" && "$1" != "mumbai" ]]; then
+          echo "Invalid network input. Please enter 'mainnet' or 'mumbai'."
+          exit 1
         fi
-        filename=`echo $line | awk -F/ '{print $NF}'`
-        if echo "$filename" | grep -q "bulk"; then
-            pv $filename | tar -I zstd -xf - -C . && rm $filename
-        else
-            pv $filename | tar -I zstd -xf - -C . --strip-components=3 && rm $filename
+      }
+    
+      function validate_client() {
+        if [[ "$1" != "heimdall" && "$1" != "bor" && "$1" != "erigon" ]]; then
+          echo "Invalid client input. Please enter 'heimdall' or 'bor' or 'erigon'."
+          exit 1
         fi
-    done < $compiled_files
-}
-
-# execute final data extraction step
-extract_files $client-$network-incremental-compiled-files.txt
-```
+      }
+    
+      function validate_checksum() {
+        if [[ "$1" != "true" && "$1" != "false" ]]; then
+          echo "Invalid checksum input. Please enter 'true' or 'false'."
+          exit 1
+        fi
+      }
+    
+      # Parse command-line arguments
+      while [[ $# -gt 0 ]]; do
+        key="$1"
+    
+        case $key in
+          -n | --network)
+            validate_network "$2"
+            network="$2"
+            shift # past argument
+            shift # past value
+            ;;
+          -c | --client)
+            validate_client "$2"
+            client="$2"
+            shift # past argument
+            shift # past value
+            ;;
+          -d | --extract-dir)
+            extract_dir="$2"
+            shift # past argument
+            shift # past value
+            ;;
+          -v | --validate-checksum)
+            validate_checksum "$2"
+            checksum="$2"
+            shift # past argument
+            shift # past value
+            ;;
+          *) # unknown option
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+        esac
+      done
+    
+      # Set default values if not provided through command-line arguments
+      network=${network:-mumbai}
+      client=${client:-heimdall}
+      extract_dir=${extract_dir:-"${client}_extract"}
+      checksum=${checksum:-false}
+    
+    
+      # temporary as we transition erigon mainnet snapshots to new incremental model, ETA Aug 2023
+      if [[ "$client" == "erigon" && "$network" == "mainnet" ]]; then
+        echo "Erigon bor-mainnet archive snapshots currently unavailable as we transition to incremental snapshot model. ETA Aug 2023."
+        exit 1
+      fi
+    
+      # install dependencies and cursor to extract directory
+      sudo apt-get update -y
+      sudo apt-get install -y zstd pv aria2
+      mkdir -p "$extract_dir"
+      cd "$extract_dir"
+    
+      # download compiled incremental snapshot files list
+      aria2c -x6 -s6 "https://snapshot-download.polygon.technology/$client-$network-parts.txt"
+    
+      # remove hash lines if user declines checksum verification
+      if [ "$checksum" == "false" ]; then
+          sed -i '/checksum/d' $client-$network-parts.txt
+      fi
+    
+      # download all incremental files, includes automatic checksum verification per increment
+      aria2c -x6 -s6 -c --auto-file-renaming=false --max-tries=100 -i $client-$network-parts.txt
+    
+      # Don't extract if download failed
+      if [ $? -ne 0 ]; then
+          echo "Download failed. Restart the script to resume downloading."
+          exit 1
+      fi
+    
+      declare -A processed_dates
+    
+      # Join bulk parts into valid tar.zst and extract
+      for file in $(find . -name "$client-$network-snapshot-bulk-*-part-*" -print | sort); do
+          date_stamp=$(echo "$file" | grep -o 'snapshot-.*-part' | sed 's/snapshot-\(.*\)-part/\1/')
+          
+          # Check if we have already processed this date
+          if [[ -z "${processed_dates[$date_stamp]}" ]]; then
+              processed_dates[$date_stamp]=1
+              output_tar="$client-$network-snapshot-${date_stamp}.tar.zst"
+              echo "Join parts for ${date_stamp} then extract"
+              cat $client-$network-snapshot-${date_stamp}-part* > "$output_tar"
+              rm $client-$network-snapshot-${date_stamp}-part*
+              pv $output_tar | tar -I zstd -xf - -C . && rm $output_tar
+          fi
+      done
+    
+      # Join incremental following day parts
+      for file in $(find . -name "$client-$network-snapshot-*-part-*" -print | sort); do
+          date_stamp=$(echo "$file" | grep -o 'snapshot-.*-part' | sed 's/snapshot-\(.*\)-part/\1/')
+          
+          # Check if we have already processed this date
+          if [[ -z "${processed_dates[$date_stamp]}" ]]; then
+              processed_dates[$date_stamp]=1
+              output_tar="$client-$network-snapshot-${date_stamp}.tar.zst"
+              echo "Join parts for ${date_stamp} then extract"
+              cat $client-$network-snapshot-${date_stamp}-part* > "$output_tar"
+              rm $client-$network-snapshot-${date_stamp}-part*
+              pv $output_tar | tar -I zstd -xf - -C . --strip-components=3 && rm $output_tar      
+          fi
+      done
+      ```
+</details>
 
 **Note:** If experiencing intermittent aria2c download errors, try reducing concurrency as exampled here:
 ```
@@ -189,3 +238,11 @@ PoS Network is deprecating Archive Node snapshots we request users to move to th
 
 Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental snapshots.
 
+
+## Recommended disk type and IOPS guidance
+- Disk IOPS will impact speed of downloading/extracting snapshots,
+  getting in sync, and performing LevelDB compaction
+- To minimize disk latency, direct attached storage is ideal
+- In AWS, when using gp3 disk types, we recommend provisioning IOPS of 16000 and
+  throughput of 1000 - this minimizes cost and adds a lot of performance. io2 EBS volumes with matching IOPS and throughput values are similarly performant
+- For GCP, we recommend using performance (SSD) persistent disks (`pd-ssd`) or extreme persistent disks (`pd-extreme`) with similar IOPS and throughput values as seen above

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -246,7 +246,7 @@ Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental sna
 ## Recommended disk type and IOPS guidance
 - Disk IOPS will impact speed of downloading/extracting snapshots,
   getting in sync, and performing LevelDB compaction
-- To minimize disk latency, direct attached storage is ideal
+- To minimize disk latency, direct attached storage is ideal.
 - In AWS, when using gp3 disk types, we recommend provisioning IOPS of 16000 and
   throughput of 1000 - this minimizes cost and adds a lot of performance. io2 EBS volumes with matching IOPS and throughput values are similarly performant
 - For GCP, we recommend using performance (SSD) persistent disks (`pd-ssd`) or extreme persistent disks (`pd-extreme`) with similar IOPS and throughput values as seen above

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -32,7 +32,7 @@ For the latest snapshot, please visit [<ins>Polygon Chains Snapshots</ins>](http
 To begin, ensure that your node environment meets the **prerequisites** outlined [here](https://wiki.polygon.technology/docs/operate/full-node-binaries/). Before starting any services, execute the shell script provided below. This script will download and extract the snapshot data, which allows for faster bootstrapping. In our example, we will be using an Ubuntu Linux m5d.4xlarge machine with an 8TB block device attached.
 To transfer the correct chaindata to your disk, follow these steps:
 
-- Specify the network ("mainnet" or "mumbai") and client type ("heimdall" or "bor" or "erigon") of your desired snapshot and run the following command:
+- All one has to do is specify the network ("mainnet" or "mumbai") and client type ("heimdall" or "bor" or "erigon") of your desired snapshot and run the following command:
 ```
 curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --network {{ network }} --client {{ client }} --extract-dir chaindata --validate-checksum true
 ```
@@ -175,7 +175,7 @@ curl -L https://snapshot-download.polygon.technology/snapdown.sh | bash -s -- --
 
 **Note:** If experiencing intermittent aria2c download errors, try reducing concurrency as exampled here:
 ```
-aria2c -c -m 0 -x6 -s6 -i heimdall-$network-incremental-compiled-files.txt --max-concurrent-downloads=1
+aria2c -c -m 0 -x6 -s6 -i $client-$network-parts.txt --max-concurrent-downloads=1
 ```
 
 Once the extraction is complete, ensure that you update the datadir configuration of your client to point to the path where the extracted data is located.

--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -249,4 +249,4 @@ Currently under maintenance. ETA Aug 2023 for Erigon bor-mainnet incremental sna
 - To minimize disk latency, direct attached storage is ideal.
 - In AWS, when using gp3 disk types, we recommend provisioning IOPS of 16000 and
   throughput of 1000 - this minimizes cost and adds a lot of performance. io2 EBS volumes with matching IOPS and throughput values are similarly performant.
-- For GCP, we recommend using performance (SSD) persistent disks (`pd-ssd`) or extreme persistent disks (`pd-extreme`) with similar IOPS and throughput values as seen above
+- For GCP, we recommend using performance (SSD) persistent disks (`pd-ssd`) or extreme persistent disks (`pd-extreme`) with similar IOPS and throughput values as seen above.


### PR DESCRIPTION
**purpose:**
- continue to simplify UX, chaindata snapshots are now a 1-line cli cmd
- add support for split snapshots (backend refactor that split large chaindata files into 25G parts for better caching)
- provided disk type and IOPS guidance to node operators

**tests:**
- fully tested on new nodes
- ensured clients are able to start successfully from snapshots