### PR TITLE
fix: ln snapshot to bor right place

### DIFF
--- a/docs/pos/reference/snapshot-instructions-heimdall-bor.md
+++ b/docs/pos/reference/snapshot-instructions-heimdall-bor.md
@@ -204,8 +204,11 @@ rm -rf /var/lib/bor/chaindata
 # rename and setup symlinks to match default client datadir configs
 mv ~/snapshots/heimdall_extract ~/snapshots/data
 mv ~/snapshots/bor_extract ~/snapshots/chaindata
+# make directories /var/lib/bor/data/bor/chaindata and /var/lib/heimdall/data not exist
+# /var/lib/heimdall/data -> ~/snapshots/data
 sudo ln -s ~/snapshots/data /var/lib/heimdall
-sudo ln -s ~/snapshots/chaindata /var/lib/bor
+# make /var/lib/bor/data/bor/chaindata -> ~/snapshots/chaindata
+sudo ln -s ~/snapshots/chaindata /var/lib/bor/data/bor
 
 # bring up clients with all snapshot data properly registered
 sudo service heimdalld start


### PR DESCRIPTION
I follow the official wiki to download snapshot and link the directories, and some errors occur to me.

and I review the bor service logs use command:

` journalctl -u bor.service -f`

and I saw this

```
INFO [08-10|06:53:56.248|ethdb/leveldb/leveldb.go:117]       Allocated cache and file handles         database=/var/lib/bor/data/bor/chaindata cache=2.00GiB handles=262,144
```

I want to  know whether there is a typo in this document

and my bor config file location in `/var/lib/bor/config.toml`

```
chain = "mainnet"
# identity = "node_name"
# verbosity = 3
vmdebug = true
datadir = "/var/lib/bor/data"
# ancient = ""
# keystore = ""
# "rpc.batchlimit" = 100
# "rpc.returndatalimit" = 100000
syncmode = "full"
# gcmode = "full"
# snapshot = true
# ethstats = ""
# devfakeauthor = false
```
