### PR TITLE
fix(pos): graphql server ports

### DIFF
--- a/docs/pos/reference/port_management.md
+++ b/docs/pos/reference/port_management.md
@@ -22,7 +22,7 @@ Here is a list of default ports used across Polygon nodes:
 | Network listening port | 30303 | public                    | Network listening port. Bor uses this port to connect to peers and sync                                        |
 | RPC server             | 8545  | can-be-public, internal   | RPC port to send transaction and get data from Bor. Heimdall uses this port to get Bor headers for checkpoints |
 | WS server              | 8546  | can-be-public, internal   | Websocket port                                                                                                 |
-| Graphql server         | 8547  | can-be-public, internal   | Graphql port                                                                                                   |
+| Graphql server         | 8547  | internal                  | Graphql port                                                                                                   |
 | Prometheus server      | 9091  | can-be-public, monitoring | Prometheus server APIs as datasource in Grafana. It can be mapped to 80/443 through nginx reverse proxy        |
 | Grafana server         | 3001  | can-be-public, monitoring | Grafana web sever. It can be mapped to 80/443 through nginx reverse proxy                                      |
 | Pprof server           | 7071  | internal, monitoring      | Pprof server to collect metrics from Bor                                                                       |
@@ -35,7 +35,7 @@ Here is a list of default ports used across Polygon nodes:
 | Network listening port | 30303 | public                    | Network listening port. Bor uses this port to connect to peers and sync                                        |
 | RPC server             | 8545  | can-be-public, internal   | RPC port to send transaction and get data from Bor. Heimdall uses this port to get Bor headers for checkpoints |
 | WS server              | 8546  | can-be-public, internal   | Websocket port                                                                                                 |
-| Graphql server         | 8547  | can-be-public, internal   | Graphql port                                                                                                   |
+| Graphql server         | 8547  | internal                  | Graphql port                                                                                                   |
 | Prometheus server      | 9091  | can-be-public, monitoring | Prometheus server APIs as datasource in Grafana. It can be mapped to 80/443 through nginx reverse proxy        |
 | Grafana server         | 3001  | can-be-public, monitoring | Grafana web sever. It can be mapped to 80/443 through nginx reverse proxy                                      |
 | Pprof server           | 7071  | internal, monitoring      | Pprof server to collect metrics from Bor                                                                       |

--- a/docs/pos/reference/port_management.md
+++ b/docs/pos/reference/port_management.md
@@ -17,7 +17,7 @@ Here is a list of default ports used across Polygon nodes:
 
 ## Bor
 
-| ﻿Name                   | Port  | Tags                      | description                                                                                                    |
+| ﻿Name                   | Port  | Tags                      | Description                                                                                                    |
 |------------------------|-------|---------------------------|----------------------------------------------------------------------------------------------------------------|
 | Network listening port | 30303 | public                    | Network listening port. Bor uses this port to connect to peers and sync                                        |
 | RPC server             | 8545  | can-be-public, internal   | RPC port to send transaction and get data from Bor. Heimdall uses this port to get Bor headers for checkpoints |
@@ -30,7 +30,7 @@ Here is a list of default ports used across Polygon nodes:
 
 ## Heimdall
 
-| ﻿Name                   | Port  | Tags                      | description                                                                                                    |
+| ﻿Name                   | Port  | Tags                      | Description                                                                                                    |
 |------------------------|-------|---------------------------|----------------------------------------------------------------------------------------------------------------|
 | Network listening port | 30303 | public                    | Network listening port. Bor uses this port to connect to peers and sync                                        |
 | RPC server             | 8545  | can-be-public, internal   | RPC port to send transaction and get data from Bor. Heimdall uses this port to get Bor headers for checkpoints |


### PR DESCRIPTION
## Context

Removes mention of `can-be-public` for graphql server port based on Immunify report.