### PR TITLE
chore(wiki): update staging deployment - temp

### DIFF
--- a/.github/workflows/staging_deployment.yml
+++ b/.github/workflows/staging_deployment.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Build
-        run: yarn build
+        run: NODE_OPTIONS="--max-old-space-size=8192" yarn build
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
Attempts to increase Node.js memory limit aimed:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```