### PR TITLE
chore(wiki): update prod deployment

### DIFF
--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Build
-        run: yarn build
+        run: NODE_OPTIONS="--max-old-space-size=8192" yarn build
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
Attempts to increase Node.js memory limit aimed:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Follows https://github.com/0xPolygon/wiki/pull/66