### PR TITLE
feat(wiki): update docusaurus config to show authors correctly

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -541,7 +541,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/0xPolygon/wiki/tree/master/",
+          editUrl: "https://github.com/0xPolygon/wiki/tree/main/",
           path: "docs",
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,


### PR DESCRIPTION
The last edited time and author names are incorrectly getting updated with each commit across Wiki. This PR updates the repo address in docusaurus config to fix it.