### PR TITLE
feat(wiki): add trailing slash

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ module.exports = {
   favicon: "img/logo-round-purple.png",
   organizationName: "Polygon Labs",
   projectName: "wiki",
+  trailingSlash: true,
   customFields: {
     description: "Build your next application on Polygon.",
   },

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,9 +6,6 @@ server {
     error_page 404 /404.html;
 
     location / {
-        if ($http_x_forwarded_proto = "http") {
-            return 301 https://$host$request_uri;
-        }
         try_files $uri.html $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
This PR adds a trailing slash in all the docs links. It will result in the addition of a slash at the end of each URL in the sitemap file which will eventually fix the indexing issue in Polygon Wiki search.