### PR TITLE
404 Fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -267,7 +267,7 @@ module.exports = {
             */
             {
               label: "Miden",
-              href: "https://wiki.polygon.technology/docs/miden/design/main"
+              href: "/docs/miden/design/main"
             },
           ]
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -267,7 +267,7 @@ module.exports = {
             */
             {
               label: "Miden",
-              href: "docs/miden/design/main"
+              href: "https://wiki.polygon.technology/docs/miden/design/main"
             },
           ]
         },


### PR DESCRIPTION
Missing forward slash render 'miden' footer link as 404 for all pages except home page