### PR TITLE
update: deployment files to fetch git commit history

### DIFF
--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      # Fetch Git history
+      - name: Fetch Git history
+        run: git fetch --unshallow
+        
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/staging_deployment.yml
+++ b/.github/workflows/staging_deployment.yml
@@ -29,6 +29,10 @@ jobs:
           role-to-assume: arn:aws:iam::070528468658:role/wiki-staging-GithubActionsRole
           role-session-name: GithubActionsSession
 
+      # Fetch Git history
+      - name: Fetch Git history
+        run: git fetch --unshallow
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
This fix allows the build environments to fetch git commit history and assign authors properly to their last edited docs. If not merged, the author of last commit is shown on every page.