### PR TITLE
update(wiki): rmv gaming from navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -436,12 +436,6 @@ module.exports = {
               target: '_self',
               rel: null,
             },
-            {
-              to: 'https://events.polygon.technology/blueprint-web3-games-guide',
-              label: 'Gaming',
-              target: '_blank',
-              rel: null,
-            },
           ],
         },
         {


### PR DESCRIPTION
## Context

Removes the experimental gaming menu option from the navbar.