### PR TITLE
update(edge): add context for proxy admin in deployment considerations

### DIFF
--- a/docs/edge/operate/deploy/rootchain-config.md
+++ b/docs/edge/operate/deploy/rootchain-config.md
@@ -230,7 +230,7 @@ A notable issue arises when the proxy contract's admin attempts to fallback to t
 
 1. **Exclusive Use of Admin Account**: Ensure that the address specified in the `--proxy-contracts-admin` flag is used exclusively for administrative functions. This includes tasks such as updating the implementation contract address and modifying the admin.
 
-2. **Avoid Using Admin as Deployer**: It's crucial to ensure that the address used in the `--proxy-contracts-admin` flag is not employed as a contract deployer. This is especially important in cases like the stake manager deployment.
+2. **Avoid Using Admin as Deployer**: Ensure that the address used in the `--proxy-contracts-admin` flag is not employed as a contract deployer. This is especially important in cases like the stake manager deployment.
 
 3. **Restricted Function Calls**: The admin account should never be used to invoke any function on the implementation contract. This restriction is in line with the design of the `TransparentUpgradeableProxy` and ensures that the admin account remains solely for administrative tasks.
 

--- a/docs/edge/operate/deploy/rootchain-config.md
+++ b/docs/edge/operate/deploy/rootchain-config.md
@@ -218,13 +218,13 @@ To deposit a desired amount and mint it on the childchain, please refer to the g
 
 ### iii. Proxy Contract Admin
 
-The introduction of the proxy contract admin flag in v1.3 of brought about new considerations for deployment and contract interaction.
+The introduction of the proxy contract admin in v1.3 brings about new considerations for deployment and contract interaction.
 
 ### Issue with Proxy Contract Fallback
 
-A notable issue arises when the proxy contract's admin attempts to fallback to the proxy target. Specifically, the initialization on a stake manager seems to be invoked using the admin account, which is set by the `--proxy-contracts-admin` flag. 
+A notable issue arises when the proxy contract's admin attempts to fallback to the proxy target. Specifically, the initialization on the StakeManager seems to be invoked using the admin account, which is set by the `--proxy-contracts-admin` flag. 
 
-According to the design of the [<ins>TransparentUpgradeableProxy</ins>](https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy), the admin account for the proxy contract is prohibited from calling any function on the implementation contract. This design choice ensures that the admin account's privileges are strictly limited to administrative tasks, preventing potential misuse or unintended interactions.
+> According to the design of the [<ins>TransparentUpgradeableProxy</ins>](https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy), the admin account for the proxy contract is prohibited from calling any function on the implementation contract. This design choice ensures that the admin account's privileges are strictly limited to administrative tasks, preventing potential misuse or unintended interactions.
 
 ### Recommendations
 


### PR DESCRIPTION
## Context

Clarifies the recommended usage of `--proxy-contracts-admin`.