### PR TITLE
feat(wiki): integrate content into CDK + presentation and format updates

### DIFF
--- a/docs/cdk/program.md
+++ b/docs/cdk/program.md
@@ -1,7 +1,7 @@
 ---
 id: cdk-program
-title: CDK Program
-sidebar_label: CDK Program
+title: The CDK Program
+sidebar_label: The CDK Program
 description: "An overview of the CDK Program."
 keywords:
   - docs
@@ -33,3 +33,5 @@ The CDK program offers a range of service providers that can assist with various
 The program offers effortless initiation for blockchain networks through "one-click" deployments, enabling developers to establish a new app-chain with utmost ease and efficiency.
 
 To start testing out by setting up a CDK-developed chain on your local machine, check out the [<ins>Quickstart</ins>](/docs/cdk/validium/quickstart.md).
+
+<!-- Add project showcase -->

--- a/docs/cdk/validium/what-is-validium.md
+++ b/docs/cdk/validium/what-is-validium.md
@@ -1,0 +1,48 @@
+---
+id: what-is-validium
+title: What are Validiums
+sidebar_label: What are Validiums?
+description: "Learn about the zkEVM-based validium offering part of the Polygon CDK."
+keywords:
+  - docs
+  - polygon
+  - layer 2
+  - validium
+  - zkValidium
+  - sdk
+  - cdk
+---
+
+Validiums are solutions that process transactions off the main Ethereum network using off-chain data availability and computation. Unlike traditional rollups, Validiums don't store transaction data on the L1 network. Instead, they generate ZK proofs, which are then published as validity proofs. This approach ensures data integrity while optimizing scalability and cost.
+
+## What do you Mean by Data Availability Layer?
+
+In the realm of blockchain, data availability ensures that all nodes can access and verify the complete transaction history, which is crucial for maintaining the network's transparency, security, and integrity.
+
+However, storing all transaction data on the main chain (L1) can lead to high costs and compromise privacy. Data availability layers tackle these issues by separating transaction execution from data storage. This allows for transaction data to be stored off-chain, reducing costs and enhancing privacy, while still being accessible for validation.
+
+This separation introduces new challenges, such as ensuring the secure and reliable management of off-chain data. Features like the [<ins>DAC</ins>](#what-are-dacs) within the Polygon CDK framework address these concerns, offering trusted oversight of off-chain data.
+
+The diagram below provides a high-level overview of the Polygon CDK Validium's approach to blockchain infrastructure.
+
+<div align="center">
+  <img src="/img/cdk/zksupernets-2.excalidraw.png" alt="bridge" width="90%" height="30%" />
+</div>
+
+## What are DACs?
+
+Data Availability Committees (DACs) are a crucial element in many blockchain protocols, tasked with ensuring the reliability and accessibility of off-chain data. In essence, they verify the availability of data associated with specific blockchain blocks.
+
+In the context of L2 solutions, DACs play a pivotal role in enhancing scalability. They aid in transferring significant computational work and data storage off-chain, thereby alleviating the burden on the main L1 blockchain.
+
+The DAC is an integral element in the validium framework of the CDK, functioning as a secure consortium of nodes to maintain the accessibility and security of off-chain data. For an overview of how the DAC functions within the CDK, please explore the DAC guide, available [<ins>here</ins>](/docs/cdk/validium/dac.md).
+
+> For a more detailed understanding of data availability, the Ethereum Foundation's guide on Data Availability is a great resource, accessible [<ins>here</ins>](https://ethereum.org/en/developers/docs/data-availability/).
+
+## How do L2s Built with Polygon CDK Validium Function as App-chains?
+
+Leveraging the power of Polygon's advanced [zkEVM technology](/docs/zkevm/), chains developed using the Polygon CDK offer a high-performance L2 scaling solution. Developers have the flexibility to choose the validium framework, which integrates a secure data availability layer managed by a [Data Availability Committee (DAC)](/docs/cdk/validium/dac.md). Chains built with the CDK can function like L1 blockchains tailored to specific business logic. However, as L2 solutions, they provide the advantage of near-infinite scalability. Designed with a user-centric approach, these chains prioritize core business functions and user engagement strategies without compromising on performance and scalability. The following diagram illustrates the high-level architecture of a chain developed using the Polygon CDK.
+
+<div align="center">
+  <img src="/img/cdk/zksupernets-6.excalidraw.png" alt="bridge" width="90%" height="30%" />
+</div>

--- a/docs/cdk/what-is-polygon-cdk.md
+++ b/docs/cdk/what-is-polygon-cdk.md
@@ -22,16 +22,16 @@ For example, a chain tailored for a specific application might leverage the zkEV
 
 The diagram below provides an overview of the key components within the CDK.
 
+<div align="center">
+  <img src="/img/cdk/cdk-stack.excalidraw.png" alt="CDK Overview" width="75%" height="30%" />
+</div>
+
 :::caution The Polygon CDK at this stage defaults to the validium
 
 As Polygon 2.0 evolves, content will be updated and expanded to reflect new configurations.
 The Edge product suite is included as part of the CDK.
 
 :::
-
-<div align="center">
-  <img src="/img/cdk/cdk-stack.excalidraw.png" alt="CDK Overview" width="75%" height="30%" />
-</div>
 
 ## What are Application-Specific Blockchains?
 

--- a/docs/cdk/what-is-polygon-cdk.md
+++ b/docs/cdk/what-is-polygon-cdk.md
@@ -39,42 +39,6 @@ Application-specific blockchains (app-chains) are specialized blockchain network
 
 However, their specificity can also lead to a lack of versatility, adaptability, and potential fragmentation in the blockchain landscape. Thus, while beneficial, these blockchains must also consider scalability, interoperability, and future-proofing.
 
-## What are Validiums?
-
-Validiums are solutions that process transactions off the main Ethereum network using off-chain data availability and computation. Unlike traditional rollups, Validiums don't store transaction data on the L1 network. Instead, they generate ZK proofs, which are then published as validity proofs. This approach ensures data integrity while optimizing scalability and cost.
-
-## How do L2s Built with Polygon CDK Function as App-chains?
-
-Leveraging the power of Polygon's advanced [zkEVM technology](/docs/zkevm/), chains developed using the Polygon CDK offer a high-performance L2 scaling solution. Developers have the flexibility to choose the validium framework, which integrates a secure data availability layer managed by a [Data Availability Committee (DAC)](/docs/cdk/validium/dac.md). Chains built with the CDK can function like L1 blockchains tailored to specific business logic. However, as L2 solutions, they provide the advantage of near-infinite scalability. Designed with a user-centric approach, these chains prioritize core business functions and user engagement strategies without compromising on performance and scalability. The following diagram illustrates the high-level architecture of a chain developed using the Polygon CDK.
-
-<div align="center">
-  <img src="/img/cdk/zksupernets-6.excalidraw.png" alt="bridge" width="90%" height="30%" />
-</div>
-
-## What do you Mean by Data Availability Layer?
-
-In the realm of blockchain, data availability ensures that all nodes can access and verify the complete transaction history, which is crucial for maintaining the network's transparency, security, and integrity.
-
-However, storing all transaction data on the main chain (L1) can lead to high costs and compromise privacy. Data availability layers tackle these issues by separating transaction execution from data storage. This allows for transaction data to be stored off-chain, reducing costs and enhancing privacy, while still being accessible for validation.
-
-This separation introduces new challenges, such as ensuring the secure and reliable management of off-chain data. Features like the [DAC](#what-are-dacs) within the Polygon CDK framework address these concerns, offering trusted oversight of off-chain data.
-
-The diagram below provides a high-level overview of the Polygon CDK Validium's approach to blockchain infrastructure.
-
-<div align="center">
-  <img src="/img/cdk/zksupernets-2.excalidraw.png" alt="bridge" width="90%" height="30%" />
-</div>
-
-## What are DACs?
-
-Data Availability Committees (DACs) are a crucial element in many blockchain protocols, tasked with ensuring the reliability and accessibility of off-chain data. In essence, they verify the availability of data associated with specific blockchain blocks.
-
-In the context of L2 solutions, DACs play a pivotal role in enhancing scalability. They aid in transferring significant computational work and data storage off-chain, thereby alleviating the burden on the main L1 blockchain.
-
-The DAC is an integral element in the validium framework of the CDK, functioning as a secure consortium of nodes to maintain the accessibility and security of off-chain data. For an overview of how the DAC functions within the CDK, please explore the DAC guide, available [<ins>here</ins>](/docs/cdk/validium/dac.md).
-
-> For a more detailed understanding of data availability, the Ethereum Foundation's guide on Data Availability is a great resource, accessible [<ins>here</ins>](https://ethereum.org/en/developers/docs/data-availability/).
-
 ## Why Choose Polygon CDK?
 
 Polygon CDK, integral to Polygon 2.0, reshapes blockchain infrastructure. It ensures unparalleled liquidity, optimizes performance, and facilitates seamless asset transfers, all while prioritizing user experience and data security.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -211,6 +211,12 @@ module.exports = {
           position: "left",
           items: [
             {
+              href: '/cdk/',
+              label: 'Welcome to the CDK',
+              target: '_self',
+              rel: null,
+            },
+            {
               href: '/cdk/what-is-polygon-cdk/',
               label: 'What is the CDK?',
               target: '_self',
@@ -279,6 +285,12 @@ module.exports = {
             {
               to: '/category/deploy-zkevm/',
               label: 'Launch a zkEVM Rollup',
+              target: '_self',
+              rel: null,
+            },
+            {
+              to: '/zkevm/architecture/',
+              label: 'zkEVM Pre-Specs',
               target: '_self',
               rel: null,
             },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,7 +235,7 @@ module.exports = {
               rel: null,
             },
             {
-              href: '/category/cdk-rollups/',
+              href: '/category/build-a-rollup-based-chain/',
               label: 'Launch a Rollup',
               target: '_self',
               rel: null,
@@ -247,8 +247,8 @@ module.exports = {
           position: "left",
           items: [
             {
-              to: '/category/polygon-zkevm/',
-              label: 'What is zkEVM?',
+              to: '/zkevm/',
+              label: 'Welcome to zkEVM',
               target: '_self',
               rel: null,
             },
@@ -265,7 +265,7 @@ module.exports = {
               rel: null,
             },
             {
-              to: '/category/build-a-zk-powered-dapp/',
+              to: '/category/start-building/',
               label: 'Build a ZK-Powered dApp',
               target: '_self',
               rel: null,
@@ -277,80 +277,8 @@ module.exports = {
               rel: null,
             },
             {
-              to: '/category/zkevm/',
+              to: '/category/deploy-zkevm/',
               label: 'Launch a zkEVM Rollup',
-              target: '_self',
-              rel: null,
-            },
-          ],
-        },
-        {
-          label: "PoS",
-          position: "left",
-          items: [
-            {
-              href: '/pos/what-is-polygon-pos/',
-              label: 'What is PoS?',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/category/polygon-pos/',
-              label: 'Get Started with PoS',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/category/polygon-pos/',
-              label: 'Learn about PoS',
-              target: '_self',
-              rel: null,
-            },
-            {
-              to: '/category/build-a-pos-powered-dapp/',
-              label: 'Build a PoS-Powered dApp',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/category/operate-a-node/',
-              label: 'Run a PoS Node',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/category/become-a-validator/',
-              label: 'Become a PoS Validator',
-              target: '_self',
-              rel: null,
-            },
-          ],
-        },
-        {
-          label: "Edge",
-          position: "left",
-          items: [
-            {
-              href: '/edge/what-is-edge/',
-              label: 'What is Edge?',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/edge/operate/quickstart/',
-              label: 'Get Started with Edge',
-              target: '_self',
-              rel: null,
-            },
-            {
-              href: '/category/system-design/',
-              label: 'Learn about Edge',
-              target: '_self',
-              rel: null,
-            },
-            {
-              to: '/category/build-an-edge-powered-chain/',
-              label: 'Deploy an Edge-Powered Chain',
               target: '_self',
               rel: null,
             },
@@ -382,6 +310,78 @@ module.exports = {
               href: 'https://0xpolygonmiden.github.io/miden-vm/',
               label: 'Learn about MidenVM',
               target: '_blank',
+              rel: null,
+            },
+          ],
+        },
+        {
+          label: "Edge",
+          position: "left",
+          items: [
+            {
+              href: '/edge/',
+              label: 'Welcome to Edge',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/edge/operate/quickstart/',
+              label: 'Get Started with Edge',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/system-design-1/',
+              label: 'Learn about Edge',
+              target: '_self',
+              rel: null,
+            },
+            {
+              to: '/category/build-an-edge-powered-chain/',
+              label: 'Deploy an Edge-Powered Chain',
+              target: '_self',
+              rel: null,
+            },
+          ],
+        },
+        {
+          label: "PoS",
+          position: "left",
+          items: [
+            {
+              href: '/pos/',
+              label: 'Welcome to PoS',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/pos/getting-started/',
+              label: 'Get Started with PoS',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/system-design/',
+              label: 'Learn about PoS',
+              target: '_self',
+              rel: null,
+            },
+            {
+              to: '/category/build-a-dapp/',
+              label: 'Build a PoS-Powered dApp',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/operate-a-node/',
+              label: 'Run a PoS Node',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/become-a-validator/',
+              label: 'Become a PoS Validator',
+              target: '_self',
               rel: null,
             },
           ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,10 +1,9 @@
 const math = require('remark-math');
 const katex = require('rehype-katex');
-const redirects = require('./redirects');
 
 module.exports = {
   title: "Polygon Wiki",
-  tagline: "The official documentation for Polygon.",
+  tagline: "The official documentation for 0xPolygon.",
   url: "https://wiki.polygon.technology",
   baseUrl: "/",
   favicon: "img/logo-round-purple.png",
@@ -14,28 +13,22 @@ module.exports = {
   customFields: {
     description: "Build your next application on Polygon.",
   },
-  plugins: [
-    [
-      '@docusaurus/plugin-client-redirects',
-      {
-        redirects: redirects,
-      },
-    ],
-  ],
   onBrokenLinks: 'log',
   themeConfig: {
     metadata: [{ name: 'description', content: 'Welcome to Polygon Wiki, the official documentation for Polygon. Learn about Polygon and its suite of Ethereum-scaling solutions.' }],
+    /*
     announcementBar: {
       id: 'banner',
       content: `
         <div class="announcement-bar">
             Discover the Next Evolution with Polygon CDK. Learn more
-            <a href="https://wiki.polygon.technology/docs/cdk" target="_self" class="announcement-link" style="color: #ffffff;">here</a>
+            <a href="https://wiki.polygon.technology/cdk" target="_self" class="announcement-link" style="color: #ffffff;">here</a>
         </div>
       `,
       textColor: '#ffffff',
       isCloseable: true,
     },
+    */
     colorMode: {
       defaultMode: 'dark',
       disableSwitch: true,
@@ -214,36 +207,36 @@ module.exports = {
       },
       items: [
         {
-          to: 'https://university.polygon.technology/',
-          label: 'New to Polygon?',
-          target: '_blank',
-          rel: null,
-        },
-        {
           label: "CDK",
           position: "left",
           items: [
             {
-              href: '/docs/cdk',
-              label: 'Welcome to the CDK',
+              href: '/cdk/what-is-polygon-cdk/',
+              label: 'What is the CDK?',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/cdk/validium/quickstart/',
-              label: 'Get Started with the Validium',
+              href: '/cdk/validium/quickstart/',
+              label: 'Get Started with the CDK',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/cdk/validium/validium-attributes/',
-              label: 'Validium System Attributes',
+              href: '/cdk/validium/validium-attributes/',
+              label: 'Learn about the Validium',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/cdk/validium/dac-overview/',
-              label: 'Data Availability',
+              href: '/cdk/validium/dac-overview/',
+              label: 'Learn about Data Availability',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/cdk-rollups/',
+              label: 'Launch a Rollup',
               target: '_self',
               rel: null,
             },
@@ -254,32 +247,38 @@ module.exports = {
           position: "left",
           items: [
             {
-              href: '/docs/zkevm/',
-              label: 'Welcome to zkEVM',
+              to: '/category/polygon-zkevm/',
+              label: 'What is zkEVM?',
               target: '_self',
               rel: null,
             },
             {
-              to: '/docs/category/start-building/',
-              label: 'Build a dApp',
+              to: '/zkevm/develop/',
+              label: 'Get Started with zkEVM',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/category/setup-zknode/',
-              label: 'Run a Node',
+              to: '/zkevm/introduction/',
+              label: 'Learn about zkEVM',
               target: '_self',
               rel: null,
             },
             {
-              to: '/docs/category/deploy-zkevm/',
-              label: 'Launch Your zkEVM',
+              to: '/category/build-a-zk-powered-dapp/',
+              label: 'Build a ZK-Powered dApp',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/category/zkevm/',
-              label: 'Pre-Specs',
+              href: '/category/setup-zknode/',
+              label: 'Run a ZK Node',
+              target: '_self',
+              rel: null,
+            },
+            {
+              to: '/category/zkevm/',
+              label: 'Launch a zkEVM Rollup',
               target: '_self',
               rel: null,
             },
@@ -290,38 +289,38 @@ module.exports = {
           position: "left",
           items: [
             {
-              href: '/docs/pos/',
-              label: 'Welcome to PoS',
+              href: '/pos/what-is-polygon-pos/',
+              label: 'What is PoS?',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/category/system-design/',
+              href: '/category/polygon-pos/',
+              label: 'Get Started with PoS',
+              target: '_self',
+              rel: null,
+            },
+            {
+              href: '/category/polygon-pos/',
               label: 'Learn about PoS',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/pos/assets/pol/',
-              label: 'Learn about POL',
+              to: '/category/build-a-pos-powered-dapp/',
+              label: 'Build a PoS-Powered dApp',
               target: '_self',
               rel: null,
             },
             {
-              to: '/docs/category/build-a-dapp/',
-              label: 'Build a dApp',
+              href: '/category/operate-a-node/',
+              label: 'Run a PoS Node',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/category/become-a-validator/',
-              label: 'Become a Validator',
-              target: '_self',
-              rel: null,
-            },
-            {
-              to: '/docs/category/proposals/',
-              label: 'Raise a Proposal',
+              href: '/category/become-a-validator/',
+              label: 'Become a PoS Validator',
               target: '_self',
               rel: null,
             },
@@ -332,26 +331,26 @@ module.exports = {
           position: "left",
           items: [
             {
-              href: '/docs/edge/',
-              label: 'Welcome to Edge',
+              href: '/edge/what-is-edge/',
+              label: 'What is Edge?',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/edge/operate/quickstart/',
+              href: '/edge/operate/quickstart/',
               label: 'Get Started with Edge',
               target: '_self',
               rel: null,
             },
             {
-              href: '/docs/category/system-design-1/',
+              href: '/category/system-design/',
               label: 'Learn about Edge',
               target: '_self',
               rel: null,
             },
             {
-              to: '/docs/category/build-an-edge-powered-chain/',
-              label: 'Deploy a Chain',
+              to: '/category/build-an-edge-powered-chain/',
+              label: 'Deploy an Edge-Powered Chain',
               target: '_self',
               rel: null,
             },
@@ -362,13 +361,19 @@ module.exports = {
           position: "left",
           items: [
             {
+              href: 'https://github.com/0xPolygonMiden',
+              label: 'What is Miden?',
+              target: '_blank',
+              rel: null,
+            },
+            {
               href: 'https://0xpolygonmiden.github.io/examples/',
               label: 'Get Started with Miden',
               target: '_blank',
               rel: null,
             },
             {
-              href: 'https://0xpolygonmiden.github.io/miden-base/introduction.html',
+              href: 'https://github.com/0xPolygonMiden/miden-base/tree/main/docs/src',
               label: 'Learn about the Miden Rollup',
               target: '_blank',
               rel: null,
@@ -389,32 +394,25 @@ module.exports = {
           rel: null,
         },
         {
-          label: "Apps & Tools",
+          label: "Support",
           position: "right",
           items: [
             {
-              href: '/docs/tools/matic-js/get-started',
-              label: 'Matic.js',
-              target: '_self',
+              href: 'https://support.polygon.technology/support/solutions',
+              label: 'Knowledge Base',
+              target: '_blank',
               rel: null,
             },
             {
-              href: '/docs/tools/chain-indexer-framework/overview',
-              label: 'Chain Indexer Framework',
-              target: '_self',
+              href: 'https://support.polygon.technology/support/home',
+              label: 'Raise a Ticket',
+              target: '_blank',
               rel: null,
             },
           ],
         },
         {
-          to: 'https://support.polygon.technology/support/solutions',
-          label: 'Support',
-          position: "right",
-          target: '_blank',
-          rel: null,
-        },
-        {
-          to: '/docs/contribute/orientation/',
+          to: '/contribute/orientation/',
           label: 'Contribute',
           position: "right",
           target: '_self',
@@ -443,6 +441,7 @@ module.exports = {
       "@docusaurus/preset-classic",
       {
         docs: {
+          routeBasePath: '/',
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: "https://github.com/0xPolygon/wiki/tree/main/",
           path: "docs",

--- a/sidebars.js
+++ b/sidebars.js
@@ -837,93 +837,164 @@ module.exports = {
     },
     "zkevm/open-source-repos",
   ],
-  /*
-   *
-   * ************************** Edge Section *************************
-   *
-   * This section includes the official product documentation and
-   * developer guides for Polygon Edge.
-   *
-   * **********************************************************************
-   *
-   */
 
-  edge: [
-    {
-      type: "html",
-      value: "Polygon Edge",
-      className: "sidebar-title",
-    },
-    "edge/index",
-    "edge/what-is-edge",
-    "edge/operate/quickstart",
+ /*
+  *
+  * ************************** CDK Section *************************
+  *
+  * This section includes the official product documentation and
+  * developer guides for Polygon CDK.
+  *
+  * **********************************************************************
+  *
+  */
+
+ cdk:[
+ {
+  type: "category",
+  label: "Polygon Chain Development Kit",
+  link: {
+    type: "generated-index",
+  },
+  items: [
+    "cdk/what-is-polygon-cdk",
+    "cdk/cdk-program",
+{
+  type: "category",
+  label: "Validium",
+  link: {
+    type: "generated-index",
+  },
+  collapsed: true,
+  items: [
+          "cdk/validium/validium-attributes",
+          "cdk/validium/dac-overview",
+          "cdk/validium/differences-validium-zkevm",
+          "cdk/validium/allowlists",
+          ],
+},
+{
+  type: "category",
+  label: "Rollups",
+  link: {
+    type: "generated-index",
+  },
+  collapsed: true,
+  items: [
     {
       type: "category",
-      label: "System Design",
+      label: "zkEVM",
       link: {
         type: "generated-index",
       },
       collapsed: true,
       items: [
-        "edge/design/overview",
+         {
+           type: "category",
+           label: "Setup zkNode",
+           link: {
+             type: "generated-index",
+           },
+           collapsed: true,
+           items: ["zkevm/setup-local-node", 
+                  "zkevm/setup-production-node"
+                ],
+         },
+         {
+           type: "category",
+           label: "Deploy zkEVM",
+           link: {
+             type: "generated-index",
+           },
+           collapsed: true,
+           items: [
+             "zkevm/deploy-fullzkevm",
+             "zkevm/step2-fullzkevm",
+             "zkevm/step3-fullzkevm",
+             "zkevm/step4-fullzkevm",
+             "zkevm/step5-fullzkevm",
+             "zkevm/step6-fullzkevm",
+             "zkevm/setup-goerlinode",
+           ],
+         },
+         {
+           type: "category",
+           label: "FAQs",
+           link: {
+             type: "generated-index",
+           },
+           collapsed: true,
+           items: [
+             "zkevm/faq/zkevm-general-faq",
+             "zkevm/faq/zkevm-protocol-faq",
+             "zkevm/faq/zkevm-eth-faq",
+             "zkevm/risk-disclosure",
+           ],
+         },
+         //"zkevm/open-source-repos",
+             ],
+    },
+    {
+      type: "category",
+      label: "Miden - Testnet",
+      link: {
+        type: "generated-index",
+      },
+      collapsed: true,
+      items: [
         {
-          type: "category",
-          label: "Consensus",
-          link: {
-            type: "generated-index",
-          },
-          items: [
-            "edge/design/consensus/polybft/polybft-overview",
-            "edge/design/consensus/polybft/ibft-overview",
-          ],
+          type: 'link',
+          label: 'Get Started with Miden',
+          href: 'https://0xpolygonmiden.github.io/examples/',
         },
         {
-          type: "category",
-          label: "Bridge",
-          link: {
-            type: "generated-index",
-          },
-          items: [
-            "edge/design/bridge/overview",
-            "edge/design/bridge/statesync",
-            "edge/design/bridge/checkpoint",
-            {
-              type: "category",
-              label: "Assets",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "edge/design/bridge/assets/erc/erc20",
-                "edge/design/bridge/assets/erc/erc721",
-                "edge/design/bridge/assets/erc/erc1155",
-              ],
-            },
-          ],
+          type: 'link',
+          label: 'Deploy a Miden Rollup',
+          href: 'https://github.com/0xPolygonMiden/miden-base/tree/main/docs/src',
         },
-        "edge/design/libp2p",
-        {
-          type: "category",
-          label: "Runtime",
-          link: {
-            type: "generated-index",
-          },
-          items: [
-            "edge/design/runtime/runtime",
-            "edge/design/runtime/runtime-allowlist",
-          ],
-        },
-        "edge/design/blockchain",
-        "edge/design/mempool",
-        "edge/design/txpool",
-        "edge/design/txrelayer",
-        "edge/design/json-rpc",
-        "edge/design/grpc",
+      ],
+    },
+  ],
+},
+{
+  type: "category",
+  label: "Edge",
+  link: {
+    type: "generated-index",
+  },
+  collapsed: true,
+  items: [
+    {
+      type: "category",
+      label: "Prepare Your Environment",
+      link: {
+        type: "generated-index",
+      },
+      collapsed: true,
+      items: [
+        "edge/operate/requirements",
+        "edge/operate/install",
+      ],
+    },
+    "edge/operate/ibft-to-polybft",
+    {
+      type: "category",
+      label: "Deploy a Chain",
+      link: {
+        type: "generated-index",
+      },
+      items: [
+        "edge/operate/deploy/deploy-index",
+        "edge/operate/deploy/spawn-test-chain",
+        "edge/operate/deploy/how-to-generate-genesis",
+        "edge/operate/deploy/how-to-configure-rootchain",
+        "edge/operate/deploy/genesis-validators",
+        "edge/operate/deploy/how-to-start",
       ],
     },
     {
       type: "category",
-      label: "Build an Edge-Powered Chain",
+      label: "Operate Your Chain",
       link: {
         type: "generated-index",
       },
@@ -931,86 +1002,51 @@ module.exports = {
       items: [
         {
           type: "category",
-          label: "Prepare Your Environment",
-          link: {
-            type: "generated-index",
-          },
-          collapsed: true,
-          items: ["edge/operate/requirements", "edge/operate/install"],
-        },
-        "edge/operate/ibft-to-polybft",
-        {
-          type: "category",
-          label: "Deploy a Chain",
-          link: {
-            type: "generated-index",
-          },
-          items: [
-            "edge/operate/deploy/deploy-index",
-            "edge/operate/deploy/spawn-test-chain",
-            "edge/operate/deploy/how-to-generate-genesis",
-            "edge/operate/deploy/how-to-configure-rootchain",
-            "edge/operate/deploy/genesis-validators",
-            "edge/operate/deploy/how-to-start",
-          ],
-        },
-        {
-          type: "category",
-          label: "Operate Your Chain",
+          label: "Access Control",
           link: {
             type: "generated-index",
           },
           collapsed: true,
           items: [
-            {
-              type: "category",
-              label: "Access Control",
-              link: {
-                type: "generated-index",
-              },
-              collapsed: true,
-              items: [
-                "edge/operate/deploy/access-control/allowlist-add-remove",
-              ],
-            },
-            {
-              type: "category",
-              label: "Staking",
-              link: {
-                type: "generated-index",
-              },
-              collapsed: true,
-              items: [
-                "edge/operate/deploy/staking/how-to-stake",
-                "edge/operate/deploy/staking/unstake",
-              ],
-            },
-            {
-              type: "category",
-              label: "Transfers",
-              link: {
-                type: "generated-index",
-              },
-              collapsed: true,
-              items: [
-                "edge/operate/deploy/transfers/cross-chain-deposit",
-                "edge/operate/deploy/transfers/cross-chain-withdraw",
-              ],
-            },
+            "edge/operate/deploy/access-control/allowlist-add-remove",
           ],
         },
         {
           type: "category",
-          label: "Upgrade Your Chain",
+          label: "Staking",
           link: {
             type: "generated-index",
           },
           collapsed: true,
           items: [
-            "edge/operate/deploy/upgrades/how-to-upgrade",
-            "edge/operate/deploy/upgrades/v1.1-hardforks",
+            "edge/operate/deploy/staking/how-to-stake",
+            "edge/operate/deploy/staking/unstake",
           ],
         },
+        {
+          type: "category",
+          label: "Transfers",
+          link: {
+            type: "generated-index",
+          },
+          collapsed: true,
+          items: [
+            "edge/operate/deploy/transfers/cross-chain-deposit",
+            "edge/operate/deploy/transfers/cross-chain-withdraw",
+          ],
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Upgrade Your Chain",
+      link: {
+        type: "generated-index",
+      },
+      collapsed: true,
+      items: [
+        "edge/operate/deploy/upgrades/how-to-upgrade",
+        "edge/operate/deploy/upgrades/v1.1-hardforks",
       ],
     },
     {
@@ -1139,33 +1175,10 @@ module.exports = {
     },
     "edge/faq",
   ],
-  /*
-   *
-   * ************************** CDK Section *************************
-   *
-   * This section includes the official product documentation and
-   * developer guides for Polygon CDK.
-   *
-   * **********************************************************************
-   *
-   */
-
-  cdk: [
-    {
-      type: "html",
-      value: "Polygon Chain Development Kit",
-      className: "sidebar-title",
-    },
-    "cdk/index",
-    "cdk/what-is-polygon-cdk",
-    "cdk/validium/quickstart",
-    "cdk/validium/validium-attributes",
-    "cdk/validium/dac-overview",
-    "cdk/validium/differences-validium-zkevm",
-    "cdk/validium/allowlists",
-    "cdk/cdk-program",
-  ],
-
+},
+],
+},
+],
   /*
    *
    * ***************************** Specs Section **************************

--- a/sidebars.js
+++ b/sidebars.js
@@ -24,8 +24,8 @@ module.exports = {
       className: "sidebar-title",
     },
     "pos/index",
-    "pos/getting-started",
     "pos/what-is-polygon-pos",
+    "pos/getting-started",
     {
       type: "category",
       label: "Assets",
@@ -837,164 +837,93 @@ module.exports = {
     },
     "zkevm/open-source-repos",
   ],
+  /*
+   *
+   * ************************** Edge Section *************************
+   *
+   * This section includes the official product documentation and
+   * developer guides for Polygon Edge.
+   *
+   * **********************************************************************
+   *
+   */
 
- /*
-  *
-  * ************************** CDK Section *************************
-  *
-  * This section includes the official product documentation and
-  * developer guides for Polygon CDK.
-  *
-  * **********************************************************************
-  *
-  */
-
- cdk:[
- {
-  type: "category",
-  label: "Polygon Chain Development Kit",
-  link: {
-    type: "generated-index",
-  },
-  items: [
-    "cdk/what-is-polygon-cdk",
-    "cdk/cdk-program",
-{
-  type: "category",
-  label: "Validium",
-  link: {
-    type: "generated-index",
-  },
-  collapsed: true,
-  items: [
-          "cdk/validium/validium-attributes",
-          "cdk/validium/dac-overview",
-          "cdk/validium/differences-validium-zkevm",
-          "cdk/validium/allowlists",
+  edge: [
+    {
+      type: "html",
+      value: "Polygon Edge",
+      className: "sidebar-title",
+    },
+    "edge/index",
+    "edge/what-is-edge",
+    "edge/operate/quickstart",
+    {
+      type: "category",
+      label: "System Design",
+      link: {
+        type: "generated-index",
+      },
+      collapsed: true,
+      items: [
+        "edge/design/overview",
+        {
+          type: "category",
+          label: "Consensus",
+          link: {
+            type: "generated-index",
+          },
+          items: [
+            "edge/design/consensus/polybft/polybft-overview",
+            "edge/design/consensus/polybft/ibft-overview",
           ],
-},
-{
-  type: "category",
-  label: "Rollups",
-  link: {
-    type: "generated-index",
-  },
-  collapsed: true,
-  items: [
-    {
-      type: "category",
-      label: "zkEVM",
-      link: {
-        type: "generated-index",
-      },
-      collapsed: true,
-      items: [
-         {
-           type: "category",
-           label: "Setup zkNode",
-           link: {
-             type: "generated-index",
-           },
-           collapsed: true,
-           items: ["zkevm/setup-local-node", 
-                  "zkevm/setup-production-node"
-                ],
-         },
-         {
-           type: "category",
-           label: "Deploy zkEVM",
-           link: {
-             type: "generated-index",
-           },
-           collapsed: true,
-           items: [
-             "zkevm/deploy-fullzkevm",
-             "zkevm/step2-fullzkevm",
-             "zkevm/step3-fullzkevm",
-             "zkevm/step4-fullzkevm",
-             "zkevm/step5-fullzkevm",
-             "zkevm/step6-fullzkevm",
-             "zkevm/setup-goerlinode",
-           ],
-         },
-         {
-           type: "category",
-           label: "FAQs",
-           link: {
-             type: "generated-index",
-           },
-           collapsed: true,
-           items: [
-             "zkevm/faq/zkevm-general-faq",
-             "zkevm/faq/zkevm-protocol-faq",
-             "zkevm/faq/zkevm-eth-faq",
-             "zkevm/risk-disclosure",
-           ],
-         },
-         //"zkevm/open-source-repos",
-             ],
-    },
-    {
-      type: "category",
-      label: "Miden - Testnet",
-      link: {
-        type: "generated-index",
-      },
-      collapsed: true,
-      items: [
-        {
-          type: 'link',
-          label: 'Get Started with Miden',
-          href: 'https://0xpolygonmiden.github.io/examples/',
         },
         {
-          type: 'link',
-          label: 'Deploy a Miden Rollup',
-          href: 'https://github.com/0xPolygonMiden/miden-base/tree/main/docs/src',
+          type: "category",
+          label: "Bridge",
+          link: {
+            type: "generated-index",
+          },
+          items: [
+            "edge/design/bridge/overview",
+            "edge/design/bridge/statesync",
+            "edge/design/bridge/checkpoint",
+            {
+              type: "category",
+              label: "Assets",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "edge/design/bridge/assets/erc/erc20",
+                "edge/design/bridge/assets/erc/erc721",
+                "edge/design/bridge/assets/erc/erc1155",
+              ],
+            },
+          ],
         },
-      ],
-    },
-  ],
-},
-{
-  type: "category",
-  label: "Edge",
-  link: {
-    type: "generated-index",
-  },
-  collapsed: true,
-  items: [
-    {
-      type: "category",
-      label: "Prepare Your Environment",
-      link: {
-        type: "generated-index",
-      },
-      collapsed: true,
-      items: [
-        "edge/operate/requirements",
-        "edge/operate/install",
-      ],
-    },
-    "edge/operate/ibft-to-polybft",
-    {
-      type: "category",
-      label: "Deploy a Chain",
-      link: {
-        type: "generated-index",
-      },
-      items: [
-        "edge/operate/deploy/deploy-index",
-        "edge/operate/deploy/spawn-test-chain",
-        "edge/operate/deploy/how-to-generate-genesis",
-        "edge/operate/deploy/how-to-configure-rootchain",
-        "edge/operate/deploy/genesis-validators",
-        "edge/operate/deploy/how-to-start",
+        "edge/design/libp2p",
+        {
+          type: "category",
+          label: "Runtime",
+          link: {
+            type: "generated-index",
+          },
+          items: [
+            "edge/design/runtime/runtime",
+            "edge/design/runtime/runtime-allowlist",
+          ],
+        },
+        "edge/design/blockchain",
+        "edge/design/mempool",
+        "edge/design/txpool",
+        "edge/design/txrelayer",
+        "edge/design/json-rpc",
+        "edge/design/grpc",
       ],
     },
     {
       type: "category",
-      label: "Operate Your Chain",
+      label: "Build an Edge-Powered Chain",
       link: {
         type: "generated-index",
       },
@@ -1002,51 +931,86 @@ module.exports = {
       items: [
         {
           type: "category",
-          label: "Access Control",
+          label: "Prepare Your Environment",
           link: {
             type: "generated-index",
           },
           collapsed: true,
+          items: ["edge/operate/requirements", "edge/operate/install"],
+        },
+        "edge/operate/ibft-to-polybft",
+        {
+          type: "category",
+          label: "Deploy a Chain",
+          link: {
+            type: "generated-index",
+          },
           items: [
-            "edge/operate/deploy/access-control/allowlist-add-remove",
+            "edge/operate/deploy/deploy-index",
+            "edge/operate/deploy/spawn-test-chain",
+            "edge/operate/deploy/how-to-generate-genesis",
+            "edge/operate/deploy/how-to-configure-rootchain",
+            "edge/operate/deploy/genesis-validators",
+            "edge/operate/deploy/how-to-start",
           ],
         },
         {
           type: "category",
-          label: "Staking",
+          label: "Operate Your Chain",
           link: {
             type: "generated-index",
           },
           collapsed: true,
           items: [
-            "edge/operate/deploy/staking/how-to-stake",
-            "edge/operate/deploy/staking/unstake",
+            {
+              type: "category",
+              label: "Access Control",
+              link: {
+                type: "generated-index",
+              },
+              collapsed: true,
+              items: [
+                "edge/operate/deploy/access-control/allowlist-add-remove",
+              ],
+            },
+            {
+              type: "category",
+              label: "Staking",
+              link: {
+                type: "generated-index",
+              },
+              collapsed: true,
+              items: [
+                "edge/operate/deploy/staking/how-to-stake",
+                "edge/operate/deploy/staking/unstake",
+              ],
+            },
+            {
+              type: "category",
+              label: "Transfers",
+              link: {
+                type: "generated-index",
+              },
+              collapsed: true,
+              items: [
+                "edge/operate/deploy/transfers/cross-chain-deposit",
+                "edge/operate/deploy/transfers/cross-chain-withdraw",
+              ],
+            },
           ],
         },
         {
           type: "category",
-          label: "Transfers",
+          label: "Upgrade Your Chain",
           link: {
             type: "generated-index",
           },
           collapsed: true,
           items: [
-            "edge/operate/deploy/transfers/cross-chain-deposit",
-            "edge/operate/deploy/transfers/cross-chain-withdraw",
+            "edge/operate/deploy/upgrades/how-to-upgrade",
+            "edge/operate/deploy/upgrades/v1.1-hardforks",
           ],
         },
-      ],
-    },
-    {
-      type: "category",
-      label: "Upgrade Your Chain",
-      link: {
-        type: "generated-index",
-      },
-      collapsed: true,
-      items: [
-        "edge/operate/deploy/upgrades/how-to-upgrade",
-        "edge/operate/deploy/upgrades/v1.1-hardforks",
       ],
     },
     {
@@ -1175,6 +1139,67 @@ module.exports = {
     },
     "edge/faq",
   ],
+
+ /*
+  *
+  * ************************** CDK Section *************************
+  *
+  * This section includes the official product documentation and
+  * developer guides for Polygon CDK.
+  *
+  * **********************************************************************
+  *
+  */
+
+ cdk:[
+ {
+  type: "category",
+  label: "Polygon Chain Development Kit",
+  link: {
+    type: "generated-index",
+  },
+  items: [
+    "cdk/what-is-polygon-cdk",
+    "cdk/cdk-program",
+    "cdk/validium/quickstart",
+{
+  type: "category",
+  label: "Build a Validium-Based Chain",
+  link: {
+    type: "generated-index",
+  },
+  collapsed: true,
+  items: [
+          "cdk/validium/validium-attributes",
+          "cdk/validium/dac-overview",
+          "cdk/validium/differences-validium-zkevm",
+          "cdk/validium/allowlists",
+          ],
+},
+{
+  type: "category",
+  label: "Build a Rollup-Based Chain",
+  link: {
+    type: "generated-index",
+  },
+  collapsed: true,
+  items: [
+    {
+      type: 'link',
+      label: 'Get Started with zkEVM',
+      href: 'https://wiki.polygon.technology/zkevm/',
+    },
+    {
+      type: 'link',
+      label: 'Get Started with Miden',
+      href: 'https://0xpolygonmiden.github.io/examples/',
+    },
+  ],
+},
+{
+  type: 'link',
+  label: 'Build an Edge-Based Chain',
+  href: 'https://wiki.polygon.technology/edge/',
 },
 ],
 },

--- a/sidebars.js
+++ b/sidebars.js
@@ -1403,21 +1403,22 @@ module.exports = {
   },
 {
   type: "category",
-  label: "Build a Validium-Based Chain",
+  label: "Build a CDK Validium-Based Chain",
   link: {
     type: "generated-index",
   },
   collapsed: true,
   items: [
-          "cdk/validium/validium-attributes",
+          "cdk/validium/what-is-validium",
           "cdk/validium/dac-overview",
+          "cdk/validium/validium-attributes",
           "cdk/validium/differences-validium-zkevm",
           "cdk/validium/allowlists",
           ],
 },
 {
   type: "category",
-  label: "Build a Rollup-Based Chain",
+  label: "Build a CDK Rollup-Based Chain",
   link: {
     type: "generated-index",
   },
@@ -1437,7 +1438,7 @@ module.exports = {
 },
 {
   type: 'link',
-  label: 'Build an Edge-Based Chain',
+  label: 'Build a CDK Edge-Based Chain',
   href: 'https://wiki.polygon.technology/edge/',
 },
 ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,7 +20,7 @@ module.exports = {
   pos: [
     {
       type: "html",
-      value: "Polygon PoS",
+      value: "Discover",
       className: "sidebar-title",
     },
     "pos/index",
@@ -36,7 +36,7 @@ module.exports = {
     },
     {
       type: "html",
-      value: "Users",
+      value: "Use",
       className: "sidebar-title",
     },
     {
@@ -118,7 +118,7 @@ module.exports = {
     },
     {
       type: "html",
-      value: "Developers",
+      value: "Develop",
       className: "sidebar-title",
     },
     {
@@ -449,7 +449,7 @@ module.exports = {
     },
     {
       type: "html",
-      value: "Operators",
+      value: "Operate",
       className: "sidebar-title",
     },
     {
@@ -534,7 +534,7 @@ module.exports = {
     "pos/pos-faqs",
     {
       type: "html",
-      value: "Governance",
+      value: "Govern",
       className: "sidebar-title",
     },
     "pos/governance-pos",
@@ -739,12 +739,242 @@ module.exports = {
   zkevm: [
     {
       type: "html",
-      value: "Polygon zkEVM",
+      value: "Discover",
       className: "sidebar-title",
     },
     "zkevm/index",
     "zkevm/introduction",
     "zkevm/develop",
+    {
+      type: "category",
+      label: "Pre-Specifications",
+      link: {
+        type: "generated-index",
+      },
+      collapsed: true,
+      items: [
+        "zkevm/architecture",
+        {
+          type: "category",
+          label: "zkEVM Protocol",
+          link: {
+            type: "generated-index",
+          },
+          collapsed: true,
+          items: [
+            "zkevm/protocol/protocol-components",
+            "zkevm/protocol/state-management",
+            {
+              type: "category",
+              label: "Transaction Life Cycle",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/protocol/l2-transaction-cycle-intro",
+                "zkevm/protocol/transaction-execution",
+                "zkevm/protocol/transaction-batching",
+                "zkevm/protocol/transaction-sequencing",
+                "zkevm/protocol/transaction-aggregation",
+              ],
+            },
+            "zkevm/protocol/incentive-mechanism",
+            "zkevm/protocol/upgradability",
+            "zkevm/protocol/admin-role",
+            "zkevm/protocol/zkevm-upgrades-process",
+            "zkevm/protocol/security-council",
+            {
+              type: "category",
+              label: "Malfunction Resistance",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/protocol/sequencer-resistance",
+                "zkevm/protocol/aggregator-resistance",
+                "zkevm/protocol/emergency-state",
+              ],
+            },
+            {
+              type: "category",
+              label: "zkEVM Bridge",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/protocol/zkevm-bridge",
+                "zkevm/protocol/exit-tree",
+                "zkevm/protocol/bridge-smart-contract",
+                "zkevm/protocol/flow-of-asset",
+              ],
+            },
+            "zkevm/protocol/lxly-bridge",
+            "zkevm/protocol/evm-diff",
+          ],
+        },
+        "zkevm/zknode/zknode-overview",
+        {
+          type: "category",
+          label: "zkProver",
+          link: {
+            type: "generated-index",
+          },
+          collapsed: true,
+          items: [
+            "zkevm/zkProver/overview",
+            {
+              type: "category",
+              label: "Basic Concepts",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/zkProver/zkprover-design",
+                {
+                  type: "category",
+                  label: "mFibonacci SM",
+                  link: {
+                    type: "generated-index",
+                  },
+                  items: [
+                    "zkevm/zkProver/mfibonacci-overview",
+                    "zkevm/zkProver/mfibonacci-example",
+                    "zkevm/zkProver/commitment-scheme",
+                    "zkevm/zkProver/verification-scheme",
+                    "zkevm/zkProver/pil-stark",
+                    "zkevm/zkProver/pil-stark-demo",
+                  ],
+                },
+                {
+                  type: "category",
+                  label: "Generic SM",
+                  link: {
+                    type: "generated-index",
+                  },
+                  items: [
+                    "zkevm/zkProver/intro-generic-sm",
+                    "zkevm/zkProver/exec-trace-correct",
+                    "zkevm/zkProver/ending-program",
+                    "zkevm/zkProver/program-counter",
+                    "zkevm/zkProver/plookup",
+                  ],
+                },
+              ],
+            },
+            {
+              type: "category",
+              label: "Main State Machine",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/zkProver/evm-basics",
+                "zkevm/zkProver/intro-main-sm",
+                "zkevm/zkProver/the-processor",
+              ],
+            },
+            {
+              type: "category",
+              label: "STARK Recursion",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/zkProver/intro-stark-recursion",
+                "zkevm/zkProver/proving-tools",
+                "zkevm/zkProver/circom-intro-brief",
+                "zkevm/zkProver/stark-recursion-detail",
+                "zkevm/zkProver/recursion-sub-process",
+                "zkevm/zkProver/proving-architecture",
+                "zkevm/zkProver/circom-in-zkprover",
+                "zkevm/zkProver/proving-setup-phase",
+                "zkevm/zkProver/intermediate-recursion-steps",
+                "zkevm/zkProver/final-recursion-step",
+                "zkevm/zkProver/proof-generation-phase",
+              ],
+            },
+            {
+              type: "category",
+              label: "Storage SM",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/zkProver/intro-storage-sm",
+                "zkevm/zkProver/sparse-merkle-tree",
+                "zkevm/zkProver/simple-smt",
+                "zkevm/zkProver/detailed-smt-concepts",
+                "zkevm/zkProver/basic-smt-ops",
+                "zkevm/zkProver/construct-key-path",
+                "zkevm/zkProver/storage-sm-mechanism",
+                "zkevm/zkProver/executor-pil",
+              ],
+            },
+            "zkevm/zkProver/arithmetic-sm",
+            "zkevm/zkProver/binary-sm",
+            "zkevm/zkProver/memory-sm",
+            "zkevm/zkProver/mem-align-sm",
+            {
+              type: "category",
+              label: "Hashing SM",
+              link: {
+                type: "generated-index",
+              },
+              items: [
+                "zkevm/zkProver/intro-hashing-sm",
+                "zkevm/zkProver/keccak-framework",
+                "zkevm/zkProver/paddingkk-sm",
+                "zkevm/zkProver/paddingkk-bit-sm",
+                "zkevm/zkProver/bits2field-sm",
+                "zkevm/zkProver/keccakf-sm",
+                "zkevm/zkProver/poseidon-sm",
+              ],
+            },
+          ],
+        },
+        {
+          type: "category",
+          label: "zk Assembly",
+          link: {
+            type: "generated-index",
+          },
+          collapsed: true,
+          items: [
+            "zkevm/zkASM/introduction",
+            "zkevm/zkASM/basic-syntax",
+            "zkevm/zkASM/some-examples",
+          ],
+        },
+        {
+          type: "category",
+          label: "Polynomial Identity Language",
+          link: {
+            type: "generated-index",
+          },
+          collapsed: true,
+          items: [
+            "zkevm/PIL/introduction",
+            "zkevm/PIL/simple-program",
+            "zkevm/PIL/pil-compile",
+            "zkevm/PIL/pil-config",
+            "zkevm/PIL/cyclic-nature",
+            "zkevm/PIL/pil-arguments",
+            "zkevm/PIL/connect-programs",
+            "zkevm/PIL/public-values",
+            "zkevm/PIL/permutation-arg",
+            "zkevm/PIL/connect-arg",
+            "zkevm/PIL/pil-plonk",
+            "zkevm/PIL/filling-polynomial",
+            "zkevm/PIL/generate-proof",
+          ],
+        },
+      ],
+    },
+    {
+      type: "html",
+      value: "Develop",
+      className: "sidebar-title",
+    },
     {
       type: "category",
       label: "Start Building",
@@ -851,7 +1081,7 @@ module.exports = {
   edge: [
     {
       type: "html",
-      value: "Polygon Edge",
+      value: "Discover",
       className: "sidebar-title",
     },
     "edge/index",
@@ -920,6 +1150,11 @@ module.exports = {
         "edge/design/json-rpc",
         "edge/design/grpc",
       ],
+    },
+    {
+      type: "html",
+      value: "Develop",
+      className: "sidebar-title",
     },
     {
       type: "category",
@@ -1152,16 +1387,20 @@ module.exports = {
   */
 
  cdk:[
- {
-  type: "category",
-  label: "Polygon Chain Development Kit",
-  link: {
-    type: "generated-index",
+  {
+    type: "html",
+    value: "Discover",
+    className: "sidebar-title",
   },
-  items: [
-    "cdk/what-is-polygon-cdk",
-    "cdk/cdk-program",
-    "cdk/validium/quickstart",
+  "cdk/index",
+  "cdk/what-is-polygon-cdk",
+  "cdk/cdk-program",
+  "cdk/validium/quickstart",
+  {
+    type: "html",
+    value: "Develop",
+    className: "sidebar-title",
+  },
 {
   type: "category",
   label: "Build a Validium-Based Chain",
@@ -1202,250 +1441,4 @@ module.exports = {
   href: 'https://wiki.polygon.technology/edge/',
 },
 ],
-},
-],
-  /*
-   *
-   * ***************************** Specs Section **************************
-   *
-   * This section includes specifications, reference material, academia,
-   * and research-grade material related to the Polygon stack.
-   *
-   * **********************************************************************
-   *
-   */
-
-  specs: [
-    //"specs/index",
-    {
-      type: "html",
-      value: "Pre-Specifications",
-      className: "sidebar-title",
-    },
-    {
-      type: "category",
-      label: "zkEVM",
-      link: {
-        type: "generated-index",
-      },
-      collapsed: true,
-      items: [
-        "zkevm/architecture",
-        {
-          type: "category",
-          label: "zkEVM Protocol",
-          link: {
-            type: "generated-index",
-          },
-          collapsed: true,
-          items: [
-            "zkevm/protocol/protocol-components",
-            "zkevm/protocol/state-management",
-            {
-              type: "category",
-              label: "Transaction Life Cycle",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/protocol/l2-transaction-cycle-intro",
-                "zkevm/protocol/transaction-execution",
-                "zkevm/protocol/transaction-batching",
-                "zkevm/protocol/transaction-sequencing",
-                "zkevm/protocol/transaction-aggregation",
-              ],
-            },
-            "zkevm/protocol/incentive-mechanism",
-            "zkevm/protocol/upgradability",
-            "zkevm/protocol/admin-role",
-            "zkevm/protocol/zkevm-upgrades-process",
-            "zkevm/protocol/security-council",
-            {
-              type: "category",
-              label: "Malfunction Resistance",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/protocol/sequencer-resistance",
-                "zkevm/protocol/aggregator-resistance",
-                "zkevm/protocol/emergency-state",
-              ],
-            },
-            {
-              type: "category",
-              label: "zkEVM Bridge",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/protocol/zkevm-bridge",
-                "zkevm/protocol/exit-tree",
-                "zkevm/protocol/bridge-smart-contract",
-                "zkevm/protocol/flow-of-asset",
-              ],
-            },
-            "zkevm/protocol/lxly-bridge",
-            "zkevm/protocol/evm-diff",
-          ],
-        },
-        "zkevm/zknode/zknode-overview",
-        {
-          type: "category",
-          label: "zkProver",
-          link: {
-            type: "generated-index",
-          },
-          collapsed: true,
-          items: [
-            "zkevm/zkProver/overview",
-            {
-              type: "category",
-              label: "Basic Concepts",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/zkProver/zkprover-design",
-                {
-                  type: "category",
-                  label: "mFibonacci SM",
-                  link: {
-                    type: "generated-index",
-                  },
-                  items: [
-                    "zkevm/zkProver/mfibonacci-overview",
-                    "zkevm/zkProver/mfibonacci-example",
-                    "zkevm/zkProver/commitment-scheme",
-                    "zkevm/zkProver/verification-scheme",
-                    "zkevm/zkProver/pil-stark",
-                    "zkevm/zkProver/pil-stark-demo",
-                  ],
-                },
-                {
-                  type: "category",
-                  label: "Generic SM",
-                  link: {
-                    type: "generated-index",
-                  },
-                  items: [
-                    "zkevm/zkProver/intro-generic-sm",
-                    "zkevm/zkProver/exec-trace-correct",
-                    "zkevm/zkProver/ending-program",
-                    "zkevm/zkProver/program-counter",
-                    "zkevm/zkProver/plookup",
-                  ],
-                },
-              ],
-            },
-            {
-              type: "category",
-              label: "Main State Machine",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/zkProver/evm-basics",
-                "zkevm/zkProver/intro-main-sm",
-                "zkevm/zkProver/the-processor",
-              ],
-            },
-            {
-              type: "category",
-              label: "STARK Recursion",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/zkProver/intro-stark-recursion",
-                "zkevm/zkProver/proving-tools",
-                "zkevm/zkProver/circom-intro-brief",
-                "zkevm/zkProver/stark-recursion-detail",
-                "zkevm/zkProver/recursion-sub-process",
-                "zkevm/zkProver/proving-architecture",
-                "zkevm/zkProver/circom-in-zkprover",
-                "zkevm/zkProver/proving-setup-phase",
-                "zkevm/zkProver/intermediate-recursion-steps",
-                "zkevm/zkProver/final-recursion-step",
-                "zkevm/zkProver/proof-generation-phase",
-              ],
-            },
-            {
-              type: "category",
-              label: "Storage SM",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/zkProver/intro-storage-sm",
-                "zkevm/zkProver/sparse-merkle-tree",
-                "zkevm/zkProver/simple-smt",
-                "zkevm/zkProver/detailed-smt-concepts",
-                "zkevm/zkProver/basic-smt-ops",
-                "zkevm/zkProver/construct-key-path",
-                "zkevm/zkProver/storage-sm-mechanism",
-                "zkevm/zkProver/executor-pil",
-              ],
-            },
-            "zkevm/zkProver/arithmetic-sm",
-            "zkevm/zkProver/binary-sm",
-            "zkevm/zkProver/memory-sm",
-            "zkevm/zkProver/mem-align-sm",
-            {
-              type: "category",
-              label: "Hashing SM",
-              link: {
-                type: "generated-index",
-              },
-              items: [
-                "zkevm/zkProver/intro-hashing-sm",
-                "zkevm/zkProver/keccak-framework",
-                "zkevm/zkProver/paddingkk-sm",
-                "zkevm/zkProver/paddingkk-bit-sm",
-                "zkevm/zkProver/bits2field-sm",
-                "zkevm/zkProver/keccakf-sm",
-                "zkevm/zkProver/poseidon-sm",
-              ],
-            },
-          ],
-        },
-        {
-          type: "category",
-          label: "zk Assembly",
-          link: {
-            type: "generated-index",
-          },
-          collapsed: true,
-          items: [
-            "zkevm/zkASM/introduction",
-            "zkevm/zkASM/basic-syntax",
-            "zkevm/zkASM/some-examples",
-          ],
-        },
-        {
-          type: "category",
-          label: "Polynomial Identity Language",
-          link: {
-            type: "generated-index",
-          },
-          collapsed: true,
-          items: [
-            "zkevm/PIL/introduction",
-            "zkevm/PIL/simple-program",
-            "zkevm/PIL/pil-compile",
-            "zkevm/PIL/pil-config",
-            "zkevm/PIL/cyclic-nature",
-            "zkevm/PIL/pil-arguments",
-            "zkevm/PIL/connect-programs",
-            "zkevm/PIL/public-values",
-            "zkevm/PIL/permutation-arg",
-            "zkevm/PIL/connect-arg",
-            "zkevm/PIL/pil-plonk",
-            "zkevm/PIL/filling-polynomial",
-            "zkevm/PIL/generate-proof",
-          ],
-        },
-      ],
-    },
-  ],
 };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,7 +4,7 @@
  * work well for content-centric websites.
  */
 
-:root {
+ :root {
   --ifm-color-primary: #D0BAF5;
   --ifm-color-primary-dark: #0036a0;
   --ifm-color-primary-darker: #003397;
@@ -834,10 +834,10 @@ html[data-theme='dark'] .header-github-link:before {
 }
 .show-card {
   background: linear-gradient(to bottom, #ffffffe8, #fffffffa);
-  border-radius: 50px;
-  width: 100%;
-  height: 100%;
-  padding: 50px;
+  border-radius: 0px;
+  width: 90%;
+  height: 90%;
+  padding: 30px; 
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease-in-out;
   display: flex;
@@ -860,24 +860,25 @@ html[data-theme='dark'] .header-github-link:before {
 }
 
 .show-card .icon-wrapper {
-  width: 100%;
-  height: 150px;
+  width: 80%;
+  height: 100px;
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
 }
 
+
 .icon-wrapper .icon {
-  height: 120px;
+  height: 80px;
 }
 
 .show-card .title {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 8px;
+  margin-bottom: 8px;
   font-weight: 600;
-  font-size: 28px;
-  line-height: 34px;
+  font-size: 24px;
+  line-height: 30px;
   letter-spacing: -0.02em;
   color: #061024;
   font-family: 'Montserrat', sans-serif;
@@ -891,8 +892,8 @@ html[data-theme='dark'] .header-github-link:before {
 
 .show-card .descriptions {
   font-weight: normal;
-  font-size: 18px;
-  line-height: 24px;
+  font-size: 16px;
+  line-height: 22px;
   color: #3b465c;
   transition: all 0.3s ease-in-out;
   text-align: center;
@@ -990,31 +991,44 @@ html[data-theme='dark'] .header-github-link:before {
   margin: 0 5px;
 }
 
-.navbar__logo img {
-  height: 60px;
-  margin-top: -13px;
-}
-
 @import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
 
 .navbar {
-  height: 71px;
-  font-size: 1.1rem;
+  height: 60px;
+  font-size: 1.05rem;
   font-family: 'Montserrat', sans-serif;
+  display: flex;
+  align-items: center;
 }
 
-.navbar__link {
+.navbar__link, .navbar__item {
   font-weight: bold;
   color: #333;
+  padding: 0 20px;
 }
 
-[data-theme='dark'] .navbar{
+.navbar__items {
+  margin: 0;
+}
+
+.navbar__item {
+  margin: 0;
+  padding: 5px 0;
+}
+
+[data-theme='dark'] .navbar {
+  color: #fff;
+  background-color: #1a1a1a;
+}
+
+[data-theme='dark'] .navbar__link, [data-theme='dark'] .navbar__item {
   color: #fff;
 }
 
-[data-theme='dark'] .navbar__link {
-  color: #fff;
+.navbar__link:not(:last-child) {
+  margin-right: 25px;
 }
+
 
 div[role="banner"] {
   padding: 30px 0px;
@@ -1032,61 +1046,6 @@ div[role="banner"] .close:focus {
   color: #fff !important;
   opacity: 1;
 }
-
-/* DARK CARD */
-
-.dark-card {
-  background-color: #212529;
-  border-radius: 12px;
-  box-shadow: 0px 1px 4px rgba(255, 255, 255, 0.15);
-  color: #fff;
-  padding: 115px;
-  margin-top: 40px;
-  margin-bottom: 300px;
-
-  }
-
-  [data-theme='light'] .dark-card {
-  background-color: #f0f0f0;
-  }
-
-  .dark-card .custom-card img {
-    max-height: 190px;
-
-  }
-
-  .dark-card .title {
-  margin-top: 20px;
-  margin-bottom: 10px;
-  font-weight: 600;
-  font-size: 35px;
-  line-height: 64px;
-  letter-spacing: -0.04em;
-  color: #b1b1b3;
-  }
-
-  [data-theme='light'] .dark-card .title {
-  color: #061024;
-  }
-
-  .dark-card .descriptions {
-  font-weight: normal;
-  font-size: 15px;
-  line-height: 20px;
-  color: #d6d6d9;
-  }
-
-  .dark-card img {
-    width: 20%;
-    float: right;
-  }
-
-  [data-theme='light'] .dark-card .descriptions {
-  font-weight: normal;
-  font-size: 14px;
-  line-height: 20px;
-  color: #3b465c;
-  }
 
 .pt-40 {
   padding-top: 40px !important;
@@ -1167,7 +1126,7 @@ strong {
 }
 
 .index-page h1 {
-  font-size: 5em;
+  font-size: 3.2em;
   margin-bottom: 25px;
 }
 
@@ -1176,7 +1135,7 @@ strong {
 }
 
 .index-page h3 {
-  font-size: 2.1em;
+  font-size: 1.5em;
 }
 
 .index-page:not(.exclude) {
@@ -1237,7 +1196,7 @@ strong {
 @media (max-width: 1160px) {
   /* fixes navbar view in medium screen sizes */
   .navbar__item {
-    font-size: 12px;
+    font-size: 10px;
   }
 }
 
@@ -1304,124 +1263,12 @@ strong {
   }
 }
 
-.helpTranslateContainer {
-  background-image: linear-gradient(135deg, #22143D 0%, #1A0F31 100%);
-  padding: 50px 0;
-  margin-top: 70px;
-  margin-bottom: -10px;
-}
-
-.helpTranslateWrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  flex-wrap: wrap;
-}
-
-.helpTranslateWrapper h3 {
-  font-size: 2.5rem;
-  font-weight: bold;
-  color: #ffffff;
-  margin-bottom: 20px;
-}
-
-.helpTranslateWrapper p {
-  font-size: 1.2rem;
-  color: #ffffff;
-  margin-bottom: 20px;
-}
-
-.helpTranslateWrapper .section-container {
-  margin-bottom: 20px;
-}
-
-.helpTranslateWrapper h3.section-title {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #ffffff;
-  margin-bottom: 20px;
-}
-
-.helpTranslateWrapper p.section-text {
-  font-size: 1rem;
-  color: #ffffff;
-  margin-bottom: 20px;
-  max-width: 460px;
-}
-
-
 .btn-bg-primary {
   background-color: #ffffff;
   color: #6A23E7;
   border: 2px solid #ffffff;
   font-weight: bold;
 }
-
-
-/*tabs style for landing page*/
-
-.tabs-lp {
-  color: #fff;
-  font-weight: var(--ifm-font-weight-bold);
-  margin-bottom: 0px;
-  overflow-x: auto;
-  width: fit-content;
-  margin: 0 auto;
-  padding-left: 0;
-  padding-right: 0;
-  padding: 0.375rem 0.5rem;
-  justify-content: center;
-  border-radius: 40px;
-  background-color: #212026;
-  position: inherit;
-  box-sizing: border-box;
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.tabs-lp__item {
-  border-bottom: 3px solid transparent;
-  cursor: pointer;
-  display: inline-flex;
-  font-size: 1rem;
-  margin-right: 0.5rem;
-  padding: 1rem 1rem;
-}
-
-.tabs-lp__item:last-child {
-  margin-right: 0;
-}
-
-
-.tabs-lp__item:hover {
-  background-color: #212027;
-}
-
-.tabs-lp__item--active{
-  border-radius: 40px;
-  background-color: #e2e1e5;
-  color: #000;
-  border-bottom-color: #ffffff;
-}
-
-.tabs-lp__item--active{
-  border-radius: 40px;
-  background-color: #e2e1e5;
-  color: #000;
-  border-bottom-color: #ffffff;
-}
-
-.tabs-lp__item--active:hover{
-  border-radius: 40px;
-  background-color: #e2e1e5;
-  color: #000;
-  border-bottom-color: #ffffff;
-}
-
-/* ------- */
 
 .tabs-element {
   display: -ms-grid;
@@ -1483,18 +1330,6 @@ strong {
   .text-weight-medium {
       font-size: 2rem;
   }
-}
-
-.solution-status {
-  display: inline-block;
-  padding: 4px 6px;
-  border: 1.5px solid #7b3fe4;
-  border-radius: 100px;
-  transform: translate(0,-8px);
-  font-family: Spacemono, sans-serif;
-  color: #af89ee;
-  font-size: .75rem;
-  text-transform: uppercase;
 }
 
 .padding-bottom {
@@ -1631,136 +1466,6 @@ strong {
   height: 100%;
 }
 
-/* adding buttons on landing page */
-
-.button-group {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-  align-items: center;
-  grid-column-gap: 1rem;
-  grid-row-gap: 1rem;
-}
-
-.button {
-  position: relative;
-  padding: 10px 14px;
-  border-radius: 3rem;
-  box-shadow: 0 4px 8px 0 rgba(0,0,0,.1);
-  -webkit-transition: .2s;
-  transition: .2s;
-  color: #fff;
-  font-weight: 500;
-  text-align: center;
-  text-decoration: none;
-  text-transform: capitalize;
-  cursor: pointer;
-}
-
-.button {
-  background: radial-gradient(70.64% 70.64% at 50% 25.87%, #9A60FF 0%, #6A23E7 100%);
-}
-
-.button .is-icon {
-  display: flex;
-  padding-right: 10px;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  align-items: center;
-}
-
-.button.is-icon:hover {
-  -webkit-filter: grayscale(100%) brightness(264%);
-  filter: grayscale(100%) brightness(264%);
-}
-
-.w-inline-flex {
-  max-width: 100%;
-  display: inline-flex;
-}
-
-.button-icon_left-element {
-  margin-right: 12px;
-}
-
-.button-icon_left-element.is-icon-medium {
-  position: relative;
-  margin-right: 6px;
-}
-
-.text-size-small {
-  font-size: .875rem;
-}
-
-.button-icon_right-element {
-  overflow: hidden;
-}
-
-.button-icon_right-element.is-icon-medium {
-  position: relative;
-}
-
-.icon-1x1-medium {
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
-.button-group > .button:not(:first-child) {
-  border-bottom-left-radius: 3rem;
-  border-top-left-radius: 3rem;
-}
-
-.button-group > .button:not(:last-child) {
-  border-bottom-right-radius: 3rem;
-  border-top-right-radius: 3rem;
-}
-
-.button.is-secondary {
-  border: 1px solid transparent;
-  background-color: #141217;
-  background-image: -webkit-gradient(linear,left top,left bottom,from(transparent),to(hsla(0,0%,100%,0)));
-  background-image: linear-gradient(180deg,transparent,hsla(0,0%,100%,0));
-  box-shadow: 0 4px 8px 0 rgba(0,0,0,.6);
-  -webkit-transition: .2s ease-in-out;
-  transition: .2s ease-in-out;
-  color: #fff;
-  background-clip: padding-box;
-  -webkit-text-fill-color: inherit;
-}
-
-.button.is-icon.is-secondary {
-  background-image: none;
-  box-shadow: rgb(34 33 33) 0px 4px 4px 0px;
-}
-
-.button.is-icon.is-secondary:hover {
-  background-color: #212026;
-  -webkit-filter: none;
-  filter: none;
-  background-clip: padding-box;
-  -webkit-text-fill-color: inherit;
-}
-
 /* announcement bar */
 
 .announcement-bar {
@@ -1812,11 +1517,15 @@ strong {
 /* sidebar-title */
 
 .sidebar-title {
-  color: #ad7dff;
-  font-size: 1.25rem;
-  letter-spacing: 0.025rem;
-  margin: 0.7rem;
+  color: #906ce5;
+  font-size: 1.1rem;
+  letter-spacing: 0.012rem;
+  margin: 0.5rem 0;
+  padding: 0.25rem 0;
   font-weight: 500;
+  border-bottom: 1px solid #3b3b3b;
+  border-radius: 0;
+  opacity: 0.92;
 }
 
 .tabs-frame {
@@ -1826,7 +1535,6 @@ strong {
   height: 550px;
 }
 
-/* Output code block styles */
 .gray-code-block {
   background-color: #f7f7f7;
   border: 1px solid #ddd;

--- a/src/data/features.js
+++ b/src/data/features.js
@@ -5,23 +5,23 @@ export const firstRow = [
     },
     {
         title: "Build a Validium-Based App-Chain",
-        linkUrl: "/category/polygon-chain-development-kit/",
+        linkUrl: "/category/build-a-validium-based-chain/",
     },
     {
         title: "Deploy Your Own zkEVM Rollup",
-        linkUrl: "/category/zkevm/",
+        linkUrl: "/category/build-a-rollup-based-chain/",
     },
     {
         title: "Deploy Your Own Miden Rollup",
-        linkUrl: "/category/miden/",
+        linkUrl: "https://github.com/0xPolygonMiden/miden-base",
     },
     {
         title: "Build a PoS-Powered dApp",
-        linkUrl: "/category/build-a-pos-powered-dapp/",
+        linkUrl: "/category/build-a-dapp/",
     },
     {
         title: "Build a ZK-Powered dApp",
-        linkUrl: "/category/build-a-zk-powered-dapp/",
+        linkUrl: "/category/start-building/",
     },
     {
         title: "Build a dApp with Client-Side Proving",
@@ -41,10 +41,10 @@ export const firstRow = [
     },
     {
         title: "Delegate Your Tokens",
-        linkUrl: "/category/operate-a-node",
+        linkUrl: "/category/delegate-your-tokens/",
     },
     {
         title: "Participate in Governance",
-        linkUrl: "/category/become-a-validator/",
+        linkUrl: "/category/proposals/",
     },
 ];

--- a/src/data/features.js
+++ b/src/data/features.js
@@ -1,38 +1,50 @@
 export const firstRow = [
     {
-        title: "Build a Validium-based App-chain",
-        linkUrl: "/docs/cdk/",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Build next-generation app-chains using the new Polygon CDK."
+        title: "Learn about Polygon 2.0",
+        linkUrl: "https://github.com/0xPolygon/wiki#polygon-20",
     },
     {
-        title: "Deploy a zkEVM Rollup",
-        linkUrl: "/docs/category/deploy-zkevm/",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Leverage Polygon's zkEVM for secure, fast off-chain transactions, guaranteed by ZK proofs."
+        title: "Build a Validium-Based App-Chain",
+        linkUrl: "/category/polygon-chain-development-kit/",
     },
     {
-        title: "Deploy a Miden Rollup",
-        linkUrl: "https://github.com/0xPolygonMiden",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Deploy a Miden Rollup with client-side proving to scale with privacy."
+        title: "Deploy Your Own zkEVM Rollup",
+        linkUrl: "/category/zkevm/",
     },
     {
-        title: "Build a dApp on zkEVM",
-        linkUrl: "/docs/zkevm/develop",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Build highly scalable and secure applications using ZK tech."
+        title: "Deploy Your Own Miden Rollup",
+        linkUrl: "/category/miden/",
     },
     {
-        title: "Run a PoS node",
-        linkUrl: "/docs/category/operate-a-node",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Contribute to decentralized computing by running your own PoS node."
+        title: "Build a PoS-Powered dApp",
+        linkUrl: "/category/build-a-pos-powered-dapp/",
+    },
+    {
+        title: "Build a ZK-Powered dApp",
+        linkUrl: "/category/build-a-zk-powered-dapp/",
+    },
+    {
+        title: "Build a dApp with Client-Side Proving",
+        linkUrl: "https://0xpolygonmiden.github.io/examples/",
+    },
+    {
+        title: "Run a PoS Full Node",
+        linkUrl: "/category/operate-a-node",
     },
     {
         title: "Become a PoS Validator",
-        linkUrl: "/docs/category/become-a-validator/",
-        imageUrl: "img/logo-round-dark.png",
-        description: "Maintain the PoS network by becoming a validator."
+        linkUrl: "/category/become-a-validator/",
+    },
+    {
+        title: "Learn about POL",
+        linkUrl: "/pos/assets/pol/",
+    },
+    {
+        title: "Delegate Your Tokens",
+        linkUrl: "/category/operate-a-node",
+    },
+    {
+        title: "Participate in Governance",
+        linkUrl: "/category/become-a-validator/",
     },
 ];

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,58 +1,19 @@
 import * as React from "react";
-import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
-import { firstRow, thirdRow, networkBanner } from "../data/features";
-import { Container, Row, Col } from 'react-bootstrap';
+import { firstRow } from "../data/features";
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-function FirstRow({ title, status, description, linkUrl, imageUrl }) {
+function FirstRow({ title, status, description, linkUrl }) {
   return (
     <div className="col-md-4 p-8">
       <Link to={useBaseUrl(linkUrl)} activeClassName="active">
         <div className="show-card">
-          <div className="icon-wrapper">
-            <img src={useBaseUrl(imageUrl)} alt={title} className="icon" />
-          </div>
           <div className="status">{status}</div>
           <div className="title">{title}</div>
           <div className="descriptions">{description}</div>
         </div>
       </Link>
-    </div>
-  );
-}
-
-function Buttonizer({docsUrl, linkUrl}) {
-  return (
-    <div className="button-group">
-      <a href={useBaseUrl(docsUrl)} target="_blank" className="button is-icon w-inline-flex">
-        <div className="button-icon_left-element is-icon-medium">
-          <div className="text-size-small">Start Learning</div>
-        </div>
-        <div className="button-icon_right-element is-icon-medium">
-          <div className="icon-1x1-medium w-embed">
-            <svg width="auto" height="auto" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M7 17L17 7M17 7V17M17 7H7" stroke="currentcolor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </div>
-        </div>
-      </a>
-      <a href={useBaseUrl(linkUrl)} target="_blank" className="button is-icon is-secondary w-inline-flex">
-        <div className="button-icon_left-element is-icon-medium">
-          <div className="text-size-small">Start Building</div>
-        </div>
-        <div className="button-icon_right-element is-icon-medium">
-          <div className="icon-1x1-medium w-embed">
-            <svg width="auto" height="auto" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M7 17L17 7M17 7V17M17 7H7" stroke="currentcolor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </div>
-        </div>
-      </a>
     </div>
   );
 }
@@ -69,30 +30,18 @@ function smoothScrollTo(target) {
 
 function Home() {
   const context = useDocusaurusContext();
-  const { siteConfig = {} } = context;
 
   return (
-    <Layout>
       <div className="bootstrap-wrapper">
         <br />
         <div className="container">
           <div className="row">
           <div className="index-page exclude">
           <section className="section container-fluid">
-            <div className="row justify-content-center">
               <div className="col-lg-8">
                 <h1 className="mt-0"><a href="https://polygon.technology" class="landing-page-link">Polygon</a> Wiki</h1>
-                <h3 className="mt-0"> The official documentation for <a href="https://polygon.technology" class="landing-page-link">0xPolygon</a></h3>
-                <p className="lead">The <b>Polygon Wiki</b> is the source of truth for Polygon, providing comprehensive documentation, community resources, and guides for enthusiasts and developers interested in learning about or building on Polygon.</p>
-                <a href="https://university.polygon.technology/" style={{ color: '#ffffff' }}>
-                  <button className="btn btn-custom">Get started with Polygon</button>
-                </a>
-                <p><a href="#common-docs" onClick={(e) => { e.preventDefault(); smoothScrollTo('#common-docs'); }}><b>Everything is built for scale ↓</b></a></p>
+                <p className="lead">The <b>Polygon Wiki</b> is the source of truth for <a href="https://polygon.technology" class="landing-page-link">0xPolygon</a>, providing comprehensive documentation, community resources, and guides for enthusiasts and developers interested in learning about or building on Polygon.</p>
               </div>
-              <div className="col-lg-4 text-center pt-3 d-none d-lg-block">
-                <img style={{ maxWidth: '100%', maxHeight: '400px' }} src="img/polygon-logo.png" />
-              </div>
-            </div>
           </section>
           </div>
             <section id="common-docs" className="section container-fluid"></section>
@@ -102,113 +51,9 @@ function Home() {
                 <FirstRow key={idx} {...props} />
               ))}{" "}
           </div>
-
-          <div className="row">
-            <div className="index-page exclude">
-              <section className="section container-fluid">
-                <div className="row justify-content-center">
-                  <div className="col-md-10">
-                    <h3 className="mt-0">Mass Scale for Mass Adaption</h3>
-                    <p className="lead">By leveraging cutting-edge technologies like ZK cryptography and transaction rollups, Polygon is making blockchains more accessible and user-friendly than ever.</p>
-                    <p><a href="#polygon-protocol" onClick={(e) => { e.preventDefault(); smoothScrollTo('#polygon-protocols'); }}><b>Explore the Protocol Docs ↓</b></a></p>
-                  </div>
-                </div>
-              </section>
-            </div>
-            <section id="polygon-protocols" className="row container-fluid justify-content-center">
-            <Tabs className="tabs-lp" defaultValue="public" values={[
-                {label: 'Public Chains', value: 'public'},
-                {label: 'App-Specific Chains', value: 'app-specific'},
-                {label: 'Decentralized Identity', value: 'identity'},
-              ]}>
-
-            <TabItem value="public">
-              <div class="tabs-element">
-                <div class="tabs_animation-wrapper">
-                  <div class="tabs_animation-embed pb_video_embed w-embed w-iframe">
-                    <iframe src="https://player.vimeo.com/video/791153898?h=a0b62c3daa&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;loop=1&amp;autoplay=1&amp;background=1" frameborder="0" allow="autoplay" class="tabs-frame" title="Hero" data-ready="true"></iframe>
-                  </div>
-                </div>
-                <div class="tabs-content">
-                  <h4 class="text-weight-medium">Polygon PoS <span class="solution-status">Live</span></h4>
-                  <div class="padding-bottom padding-small"></div>
-                  <p class="description-text">Support the most widely used Ethereum scaling ecosystem that offers EVM compatibility and an ultimate user experience with fast transactions at near-zero gas fees today.</p>
-                  <div class="padding-bottom custom-padding"></div>
-                  <Buttonizer docsUrl={'docs/pos'} linkUrl={'docs/category/deploy-a-contract'} />
-                </div>
-              </div>
-
-              <div class="tabs-element reverse">
-                <div class="tabs-content">
-                  <h4 class="text-weight-medium">Polygon zkEVM <span class="solution-status">Mainnet Beta</span></h4>
-                  <div class="padding-bottom padding-small"></div>
-                  <p class="description-text">Unlock Ethereum scalability while maintaining security with the first ZK-rollup that offers EVM equivalence with fast transactions at near-zero gas cost today.</p>
-                  <div class="padding-bottom custom-padding"></div>
-                  <Buttonizer docsUrl={'docs/zkevm/introduction'} linkUrl={'docs/zkevm/develop'} />
-                </div>
-                <div class="tabs_animation-wrapper">
-                  <div class="tabs_animation-embed pb_video_embed w-embed w-iframe">
-                    <iframe src="https://player.vimeo.com/video/791153931?h=a0b62c3daa&badge=0&autopause=0&player_id=0&app_id=58479&loop=1&autoplay=1&background=1" frameborder="0" allow="autoplay" class="tabs-frame" title="Hero" data-ready="true"></iframe>
-                  </div>
-                </div>
-              </div>
-
-              <div class="tabs-element">
-                <div class="tabs_animation-wrapper">
-                  <div class="tabs_animation-embed pb_video_embed w-embed w-iframe">
-                    <iframe src="https://player.vimeo.com/video/791153877?h=a0b62c3daa&badge=0&autopause=0&player_id=0&app_id=58479&loop=1&autoplay=1&background=1" frameborder="0" allow="autoplay" class="tabs-frame" title="Hero" data-ready="true"></iframe>
-                  </div>
-                </div>
-                <div class="tabs-content">
-                  <h4 class="text-weight-medium">Polygon Miden <span class="solution-status">Coming Soon</span></h4>
-                  <div class="padding-bottom padding-small"></div>
-                  <p class="description-text">Build advanced dApps using client-side proving with the first decentralized rollup that leverages execution proofs of concurrent, local transactions.</p>
-                  <div class="padding-bottom custom-padding"></div>
-                  <Buttonizer docsUrl={'https://github.com/0xPolygonMiden'} linkUrl={'https://0xpolygonmiden.github.io/examples/'} />
-                </div>
-              </div>
-            </TabItem>
-
-            <TabItem value="app-specific">
-              <div class="tabs-element">
-                <div class="tabs-content">
-                  <h4 class="text-weight-medium">Polygon CDK <span class="solution-status">Live</span></h4>
-                  <div class="padding-bottom padding-small"></div>
-                  <p class="description-text">Build highly scalable, modular, and customizable layer 2 app-chains.</p>
-                  <div class="padding-bottom custom-padding"></div>
-                  <Buttonizer docsUrl={'docs/cdk/what-is-polygon-cdk/'} linkUrl={'docs/cdk/quickstart/'} />
-                </div>
-                <div class="tabs_animation-wrapper">
-                  <div class="tabs_animation-embed pb_video_embed w-embed w-iframe">
-                    <iframe src="https://player.vimeo.com/video/791153912?h=a0b62c3daa&badge=0&autopause=0&player_id=0&app_id=58479&loop=1&autoplay=1&background=1" frameborder="0" allow="autoplay" class="tabs-frame" title="Hero" data-ready="true"></iframe>
-                  </div>
-                </div>
-              </div>
-            </TabItem> 
-            <TabItem value="identity">
-              <div class="tabs-element">
-                <div class="tabs_animation-wrapper">
-                  <div class="tabs_animation-embed pb_video_embed w-embed w-iframe">
-                    <iframe src="https://player.vimeo.com/video/791153864?h=a0b62c3daa&badge=0&autopause=0&player_id=0&app_id=58479&loop=1&autoplay=1&background=1" frameborder="0" allow="autoplay" class="tabs-frame" title="Hero" data-ready="true"></iframe>
-                  </div>
-                </div>
-                <div class="tabs-content">
-                  <h4 class="text-weight-medium">Polygon ID  <span class="solution-status">Live</span></h4>
-                  <div class="padding-bottom padding-small"></div>
-                  <p class="description-text">Build trusted and secure relationships between users and dApps, following the principles of self sovereign identity and privacy by default.</p>
-                  <div class="padding-bottom custom-padding"></div>
-                  <Buttonizer docsUrl={'https://devs.polygonid.com/'} linkUrl={'https://devs.polygonid.com/docs/quick-start-demo'} />
-                </div>
-              </div>
-            </TabItem>
-
-          </Tabs>
-          </section>
-          </div>
           <br />
         </div>
       </div>
-    </Layout>
   );
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
@@ -18,20 +19,11 @@ function FirstRow({ title, status, description, linkUrl }) {
   );
 }
 
-function smoothScrollTo(target) {
-  const element = document.querySelector(target);
-  if (element) {
-    window.scrollTo({
-      behavior: 'smooth',
-      top: element.offsetTop
-    });
-  }
-}
-
 function Home() {
   const context = useDocusaurusContext();
 
   return (
+    <Layout>
       <div className="bootstrap-wrapper">
         <br />
         <div className="container">
@@ -54,6 +46,7 @@ function Home() {
           <br />
         </div>
       </div>
+      </Layout>
   );
 }
 


### PR DESCRIPTION
## Context

This update enhances the Wiki by consolidating all app-chain development paths under the Chain Development Kit (CDK) product documentation. However, we've maintained separate sidebars for each product suite's documentation.

The rationale behind this is to avoid categorizing every product suite under the CDK with the currently available content. While this is the intended deployment for each path (rollup, validium, or Edge) to facilitate chain construction, the current structure might not be ideal for representing them solely under the CDK. You can view a sample of this arrangement [here](https://polygon-wiki-temp.on.fleek.co/).

This is also because the CDK doesn't offer specific interfaces, APIs, or abstractions that would act as developer resources (and by extension, actual CDK product documentation) for each product suite intended for chain building.

### Styling Improvements

- Simplifies and refines the landing page styling.
- Enhances the styling and adjusts component sizes within the Wiki.
- Introduces various enhancements to the sidebars and the presentation of product documentation.
   - Adopts a temporary design pattern for sidebars, using "Discover" for explainer content and "Develop" for development content.
   - Refines the navbar dropdown menus.
   - Enhances the entry points.

### CDK Updates

- Integrates Edge into the CDK.
- Integrates Rollups into the CDK.

resolves #150, #151

### TO-DO

Redirects need to be reapplied again. This PR should not be merged until the associated redirects are updated, including the temporary ones that were implemented on the server side.
cc. @cerberushades @EmpieichO