### PR TITLE
Update thirdweb.md to use the correct brand name as "thirdweb" and not "thirdWeb"

### DIFF
--- a/docs/pos/deploy/thirdweb.md
+++ b/docs/pos/deploy/thirdweb.md
@@ -1,7 +1,7 @@
 ---
 id: thirdweb
-title: How to Deploy a Smart Contract Using thirdWeb
-sidebar_label: Using thirdWeb
+title: How to Deploy a Smart Contract Using thirdweb
+sidebar_label: Using thirdweb
 description: "Lean how to deploy smart contracts on Polygon PoS using thirdweb."
 keywords:
   - docs


### PR DESCRIPTION


"thirdweb" is the correct company name. All characters in the name are in small case. 

Refer to thirdweb.com for branding